### PR TITLE
Missing dep

### DIFF
--- a/modules/common/namespace/outputs.tf
+++ b/modules/common/namespace/outputs.tf
@@ -3,4 +3,6 @@ output "name" {
 }
 output "tiller_service_account" {
     value = "${kubernetes_service_account.tiller_service_account.metadata.0.name}"
+
+    depends_on = ["kubernetes_role_binding.tiller_role_binding"]
 }

--- a/stacks/environment-aws/variables.tf
+++ b/stacks/environment-aws/variables.tf
@@ -30,7 +30,7 @@ variable "opa_failure_policy" {
     default = "Fail"
 }
 variable "sdm_version" {
-    default = "0.2.14"
+    default = "0.2.15"
 }
 variable "dashboard_version" {
   default = "0.2.0-eb0f89d7cf8"


### PR DESCRIPTION
Add a depends on in the output so that the module ensures the role binding for tiller is maintained