### PR TITLE
increase jenkins readiness time

### DIFF
--- a/modules/lead/product/jenkins-values.tpl
+++ b/modules/lead/product/jenkins-values.tpl
@@ -30,9 +30,9 @@ master:
   healthProbeLivenessPeriodSeconds: 10
   healthProbeReadinessPeriodSeconds: 10
   healthProbeLivenessFailureThreshold: 5
-  healthProbeReadinessFailureThreshold: 3
-  healthProbeLivenessInitialDelay: 10000
-  healthProbeReadinessInitialDelay: 10000
+  healthProbeReadinessFailureThreshold: 10
+  healthProbeLivenessInitialDelay: 240
+  healthProbeReadinessInitialDelay: 120
 
   JCasC:
     enabled: true

--- a/modules/lead/product/jenkins-values.tpl
+++ b/modules/lead/product/jenkins-values.tpl
@@ -17,20 +17,8 @@ master:
       secretName: jenkins-ingress-tls
   jenkinsUrlProtocol: https
   serviceType: ClusterIP
-  resources:
-    requests:
-      cpu: "1000m"
-      memory: "1024Mi"
-    limits:
-      cpu: "2000m"
-      memory: "4096Mi"
-  healthProbes: true
-  healthProbesLivenessTimeout: 5
-  healthProbesReadinessTimeout: 5
-  healthProbeLivenessPeriodSeconds: 10
-  healthProbeReadinessPeriodSeconds: 10
   healthProbeLivenessFailureThreshold: 5
-  healthProbeReadinessFailureThreshold: 10
+  healthProbeReadinessFailureThreshold: 12
   healthProbeLivenessInitialDelay: 240
   healthProbeReadinessInitialDelay: 120
 

--- a/modules/lead/product/jenkins-values.tpl
+++ b/modules/lead/product/jenkins-values.tpl
@@ -24,6 +24,7 @@ master:
     limits:
       cpu: "2000m"
       memory: "4096Mi"
+  healthProbes: false
 
   JCasC:
     enabled: true
@@ -174,7 +175,3 @@ master:
     configAutoReload:
       enabled: true
       label: jenkins_config
-
-  healthProbesLivenessTimeout: 10000
-  healthProbesReadinessTimeout: 10000
-  healthProbeReadinessPeriodSeconds: 1000

--- a/modules/lead/product/jenkins-values.tpl
+++ b/modules/lead/product/jenkins-values.tpl
@@ -24,7 +24,15 @@ master:
     limits:
       cpu: "2000m"
       memory: "4096Mi"
-  healthProbes: false
+  healthProbes: true
+  healthProbesLivenessTimeout: 5
+  healthProbesReadinessTimeout: 5
+  healthProbeLivenessPeriodSeconds: 10
+  healthProbeReadinessPeriodSeconds: 10
+  healthProbeLivenessFailureThreshold: 5
+  healthProbeReadinessFailureThreshold: 3
+  healthProbeLivenessInitialDelay: 10000
+  healthProbeReadinessInitialDelay: 10000
 
   JCasC:
     enabled: true

--- a/modules/lead/product/jenkins-values.tpl
+++ b/modules/lead/product/jenkins-values.tpl
@@ -175,4 +175,5 @@ master:
       enabled: true
       label: jenkins_config
 
-  healthProbesReadinessTimeout: 500
+  healthProbesReadinessTimeout: 2000
+  healthProbeReadinessPeriodSeconds: 60

--- a/modules/lead/product/jenkins-values.tpl
+++ b/modules/lead/product/jenkins-values.tpl
@@ -168,4 +168,12 @@ master:
       enabled: true
       label: jenkins_config
 
-  healthProbesReadinessTimeout: 120
+  healthProbesReadinessTimeout: 500
+  master:
+    resources:
+      requests:
+        cpu: "1000m"
+        memory: "1024Mi"
+      limits:
+        cpu: "2000m"
+        memory: "4096Mi"

--- a/modules/lead/product/jenkins-values.tpl
+++ b/modules/lead/product/jenkins-values.tpl
@@ -17,6 +17,13 @@ master:
       secretName: jenkins-ingress-tls
   jenkinsUrlProtocol: https
   serviceType: ClusterIP
+  resources:
+    requests:
+      cpu: "1000m"
+      memory: "1024Mi"
+    limits:
+      cpu: "2000m"
+      memory: "4096Mi"
 
   JCasC:
     enabled: true
@@ -169,11 +176,3 @@ master:
       label: jenkins_config
 
   healthProbesReadinessTimeout: 500
-  master:
-    resources:
-      requests:
-        cpu: "1000m"
-        memory: "1024Mi"
-      limits:
-        cpu: "2000m"
-        memory: "4096Mi"

--- a/modules/lead/product/jenkins-values.tpl
+++ b/modules/lead/product/jenkins-values.tpl
@@ -167,3 +167,5 @@ master:
     configAutoReload:
       enabled: true
       label: jenkins_config
+
+  healthProbesReadinessTimeout: 120

--- a/modules/lead/product/jenkins-values.tpl
+++ b/modules/lead/product/jenkins-values.tpl
@@ -175,5 +175,6 @@ master:
       enabled: true
       label: jenkins_config
 
-  healthProbesReadinessTimeout: 2000
-  healthProbeReadinessPeriodSeconds: 60
+  healthProbesLivenessTimeout: 10000
+  healthProbesReadinessTimeout: 10000
+  healthProbeReadinessPeriodSeconds: 1000


### PR DESCRIPTION
jenkins container was being restarted in the middle creating product because readiness + liveness tests were failing