### PR TITLE
Added role and role binding permissions for default Service Account

### DIFF
--- a/modules/lead/product/production.tf
+++ b/modules/lead/product/production.tf
@@ -130,7 +130,7 @@ resource "kubernetes_role" "default-production-role" {
   }
 
   rule {
-    api_groups = ["", "extensions"]
+    api_groups = [""]
     resources  = ["pods", "jobs"]
     verbs      = ["get"]
   }

--- a/modules/lead/product/production.tf
+++ b/modules/lead/product/production.tf
@@ -110,3 +110,60 @@ resource "kubernetes_role_binding" "jenkins_production_rolebinding" {
   }
 }
 
+resource "kubernetes_role" "default-production-role" {
+  provider = kubernetes.production
+  metadata {
+    name      = "default-production-role"
+    namespace = module.production_namespace.name
+
+    labels = {
+      "app.kubernetes.io/name"       = "default"
+      "app.kubernetes.io/instance"   = "default"
+      "app.kubernetes.io/component"  = "default-master"
+      "app.kubernetes.io/managed-by" = "Terraform"
+    }
+
+    annotations = {
+      description = "Permission required for default Service Account to get pods and jobs in production namespace"
+      source-repo = "https://github.com/liatrio/lead-terraform"
+    }
+  }
+
+  rule {
+    api_groups = ["", "extensions"]
+    resources  = ["*"]
+    verbs      = ["*"]
+  }
+}
+
+resource "kubernetes_role_binding" "default_production_rolebinding" {
+  provider = kubernetes.production
+  metadata {
+    name      = "default-production-rolebinding"
+    namespace = module.production_namespace.name
+
+    labels = {
+      "app.kubernetes.io/name"       = "default"
+      "app.kubernetes.io/instance"   = "default"
+      "app.kubernetes.io/component"  = "default-master"
+      "app.kubernetes.io/managed-by" = "Terraform"
+    }
+
+    annotations = {
+      description = "Permission required for default Service account to get pods and jobs in production namespace"
+      source-repo = "https://github.com/liatrio/lead-terraform"
+    }
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = "default"
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = "default"
+    namespace = module.toolchain_namespace.name
+  }
+}

--- a/modules/lead/product/production.tf
+++ b/modules/lead/product/production.tf
@@ -131,8 +131,8 @@ resource "kubernetes_role" "default-production-role" {
 
   rule {
     api_groups = ["", "extensions"]
-    resources  = ["*"]
-    verbs      = ["*"]
+    resources  = ["pods", "jobs"]
+    verbs      = ["get"]
   }
 }
 

--- a/modules/lead/product/staging.tf
+++ b/modules/lead/product/staging.tf
@@ -131,8 +131,8 @@ resource "kubernetes_role" "default-staging-role" {
 
   rule {
     api_groups = ["", "extensions"]
-    resources  = ["*"]
-    verbs      = ["*"]
+    resources  = ["pods", "jobs"]
+    verbs      = ["get"]
   }
 }
 

--- a/modules/lead/product/staging.tf
+++ b/modules/lead/product/staging.tf
@@ -130,7 +130,7 @@ resource "kubernetes_role" "default-staging-role" {
   }
 
   rule {
-    api_groups = ["", "extensions"]
+    api_groups = [""]
     resources  = ["pods", "jobs"]
     verbs      = ["get"]
   }

--- a/modules/lead/product/staging.tf
+++ b/modules/lead/product/staging.tf
@@ -110,3 +110,60 @@ resource "kubernetes_role_binding" "jenkins_staging_rolebinding" {
   }
 }
 
+resource "kubernetes_role" "default-staging-role" {
+  provider = kubernetes.staging
+  metadata {
+    name      = "default-staging-role"
+    namespace = module.staging_namespace.name
+
+    labels = {
+      "app.kubernetes.io/name"       = "default"
+      "app.kubernetes.io/instance"   = "default"
+      "app.kubernetes.io/component"  = "default-master"
+      "app.kubernetes.io/managed-by" = "Terraform"
+    }
+
+    annotations = {
+      description = "Permission required for default Service Account to get pods and jobs in staging namespace"
+      source-repo = "https://github.com/liatrio/lead-terraform"
+    }
+  }
+
+  rule {
+    api_groups = ["", "extensions"]
+    resources  = ["*"]
+    verbs      = ["*"]
+  }
+}
+
+resource "kubernetes_role_binding" "default_staging_rolebinding" {
+  provider = kubernetes.staging
+  metadata {
+    name      = "default-staging-rolebinding"
+    namespace = module.staging_namespace.name
+
+    labels = {
+      "app.kubernetes.io/name"       = "default"
+      "app.kubernetes.io/instance"   = "default"
+      "app.kubernetes.io/component"  = "default-master"
+      "app.kubernetes.io/managed-by" = "Terraform"
+    }
+
+    annotations = {
+      description = "Permission required for default Service account to get pods and jobs in staging namespace"
+      source-repo = "https://github.com/liatrio/lead-terraform"
+    }
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = "default"
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = "default"
+    namespace = module.toolchain_namespace.name
+  }
+}


### PR DESCRIPTION
This PR adds permissions for the default service account to get `pod` and `job` resources.