### PR TITLE
Added list verb and updated role reference

### DIFF
--- a/modules/lead/product/production.tf
+++ b/modules/lead/product/production.tf
@@ -132,7 +132,7 @@ resource "kubernetes_role" "default-production-role" {
   rule {
     api_groups = [""]
     resources  = ["pods", "jobs"]
-    verbs      = ["get"]
+    verbs      = ["get", "list"]
   }
 }
 
@@ -158,7 +158,7 @@ resource "kubernetes_role_binding" "default_production_rolebinding" {
   role_ref {
     api_group = "rbac.authorization.k8s.io"
     kind      = "Role"
-    name      = "default"
+    name      = "default-production-role"
   }
 
   subject {

--- a/modules/lead/product/production.tf
+++ b/modules/lead/product/production.tf
@@ -130,8 +130,8 @@ resource "kubernetes_role" "default-production-role" {
   }
 
   rule {
-    api_groups = [""]
-    resources  = ["pods", "jobs"]
+    api_groups = ["", "extensions"]
+    resources  = ["pods", "jobs", "deployments"]
     verbs      = ["get", "list"]
   }
 }

--- a/modules/lead/product/staging.tf
+++ b/modules/lead/product/staging.tf
@@ -132,7 +132,7 @@ resource "kubernetes_role" "default-staging-role" {
   rule {
     api_groups = [""]
     resources  = ["pods", "jobs"]
-    verbs      = ["get"]
+    verbs      = ["get", "list"]
   }
 }
 
@@ -158,7 +158,7 @@ resource "kubernetes_role_binding" "default_staging_rolebinding" {
   role_ref {
     api_group = "rbac.authorization.k8s.io"
     kind      = "Role"
-    name      = "default"
+    name      = "default-staging-role"
   }
 
   subject {

--- a/modules/lead/product/staging.tf
+++ b/modules/lead/product/staging.tf
@@ -130,8 +130,8 @@ resource "kubernetes_role" "default-staging-role" {
   }
 
   rule {
-    api_groups = [""]
-    resources  = ["pods", "jobs"]
+    api_groups = ["", "extensions"]
+    resources  = ["pods", "jobs", "deployments"]
     verbs      = ["get", "list"]
   }
 }


### PR DESCRIPTION
This PR should contain fixes so that the `default-staging` and `default-production` role bindings reference the correct role. Also the `list` verb has been added to the role to allow listing pods and jobs.