### PR TITLE
Updated default role ref

### DIFF
--- a/modules/lead/product/production.tf
+++ b/modules/lead/product/production.tf
@@ -110,7 +110,7 @@ resource "kubernetes_role_binding" "jenkins_production_rolebinding" {
   }
 }
 
-resource "kubernetes_role" "default-production-role" {
+resource "kubernetes_role" "default_production_role" {
   provider = kubernetes.production
   metadata {
     name      = "default-production-role"
@@ -168,7 +168,7 @@ resource "kubernetes_role_binding" "default_production_rolebinding" {
   role_ref {
     api_group = "rbac.authorization.k8s.io"
     kind      = "Role"
-    name      = "default-production-role"
+    name      = kubernetes_role.default_production_role.metadata[0].name
   }
 
   subject {

--- a/modules/lead/product/staging.tf
+++ b/modules/lead/product/staging.tf
@@ -110,7 +110,7 @@ resource "kubernetes_role_binding" "jenkins_staging_rolebinding" {
   }
 }
 
-resource "kubernetes_role" "default-staging-role" {
+resource "kubernetes_role" "default_staging_role" {
   provider = kubernetes.staging
   metadata {
     name      = "default-staging-role"
@@ -168,7 +168,7 @@ resource "kubernetes_role_binding" "default_staging_rolebinding" {
   role_ref {
     api_group = "rbac.authorization.k8s.io"
     kind      = "Role"
-    name      = "default-staging-role"
+    name      = kubernetes_role.default_staging_role.metadata[0].name
   }
 
   subject {


### PR DESCRIPTION
This PR replaces default staging and productions `role_ref`s with variables to prevent race conditions when Terraform creates the roles.