### PR TITLE
Allow tiller-manager to access resources for canary deployments

### DIFF
--- a/modules/common/namespace/main.tf
+++ b/modules/common/namespace/main.tf
@@ -68,36 +68,16 @@ resource "kubernetes_role" "tiller_role" {
     resources = ["gateways", "virtualservices"]
     verbs = ["get", "create", "watch", "delete", "list", "patch"]
   }
-  # rule {
-  #   api_groups = ["autoscaling"]
-  #   resources = ["horizontalpodautoscalers"]
-  #   verbs = ["*"]
-  # }
-  # rule {
-  #   api_groups = ["appmesh.k8s.aws"]
-  #   resources = ["meshes","meshes/status","virtualnodes","virtualnodes/status","virtualservices","virtualservices/status"]
-  #   verbs = ["*"]
-  # }
-  # rule {
-  #   api_groups = ["flagger.app"]
-  #   resources = ["canaries","canaries/status"]
-  #   verbs = ["*"]
-  # }
-  # rule {
-  #   api_groups = ["gateway.solo.io"]
-  #   resources = ["gateways","virtualservices"]
-  #   verbs = ["*"]
-  # }
-  # rule {
-  #   api_groups = ["gloo.solo.io"]
-  #   resources = ["proxies","settings","upstreamgroups","upstreams","virtualservices"]
-  #   verbs = ["*"]
-  # }
-  # rule {
-  #   api_groups = ["split.smi-spec.io"]
-  #   resources = ["trafficsplits"]
-  #   verbs = ["*"]
-  # }
+  rule {
+    api_groups = ["autoscaling"]
+    resources = ["horizontalpodautoscalers"]
+    verbs = ["*"]
+  }
+  rule {
+    api_groups = ["flagger.app"]
+    resources = ["canaries","canaries/status"]
+    verbs = ["*"]
+  }
 }
 
 resource "kubernetes_role_binding" "tiller_role_binding" {


### PR DESCRIPTION
This PR gives permission to interact with Flagger and HPA resources to the `tiller-manager` role. This will allow users to define and perform Canary deployments.