### PR TITLE
ENG-1024: ensure tiller doesn't get moved by cluster-autoscaler

### DIFF
--- a/modules/common/cert-issuer/main.tf
+++ b/modules/common/cert-issuer/main.tf
@@ -22,5 +22,5 @@ resource "helm_release" "cert_manager_issuers" {
   chart     = "${path.module}/helm/cert-manager-issuers"
   timeout   = 600
   wait      = true
-  values = [data.template_file.issuer_values.rendered]
+  values = [data.template_file.issuer_values.rendered, var.external_values]
 }

--- a/modules/common/cert-issuer/variables.tf
+++ b/modules/common/cert-issuer/variables.tf
@@ -38,3 +38,6 @@ variable "enabled" {
   default = true
 }
 
+variable "external_values" {
+  default = ""
+}

--- a/modules/common/opa/main.tf
+++ b/modules/common/opa/main.tf
@@ -19,7 +19,7 @@ resource "helm_release" "opa" {
   timeout       = 900
   recreate_pods = true
 
-  values = [data.template_file.opa_values[0].rendered]
+  values = [data.template_file.opa_values[0].rendered, var.external_values]
 }
 
 resource "kubernetes_config_map" "opa-default-system-main" {

--- a/modules/common/opa/variables.tf
+++ b/modules/common/opa/variables.tf
@@ -1,5 +1,4 @@
-variable "namespace" {
-}
+variable "namespace" {}
 
 variable "enable_opa" {
   default = "true"
@@ -9,3 +8,6 @@ variable "opa_failure_policy" {
   default = "Fail"
 }
 
+variable "external_values" {
+  default = ""
+}

--- a/modules/lead/infrastructure/certmanager.tf
+++ b/modules/lead/infrastructure/certmanager.tf
@@ -46,6 +46,8 @@ resource "helm_release" "cert_manager" {
     value = "--issuer-ambient-credentials"
   }
 
+  values = [var.ondemand_toleration_values]
+
   depends_on = [
     helm_release.cert_manager_crds,
     null_resource.cert_manager_crd_delay,

--- a/modules/lead/infrastructure/external-dns.tf
+++ b/modules/lead/infrastructure/external-dns.tf
@@ -11,7 +11,7 @@ resource "helm_release" "external_dns" {
   name       = "external-dns"
   timeout    = 600
 
-  values = [var.external_dns_chart_values]
+  values = [var.external_dns_chart_values, var.ondemand_toleration_values]
   set {
     name  = "rbac.serviceAccountName"
     value = kubernetes_service_account.external_dns_service_account.metadata[0].name

--- a/modules/lead/infrastructure/main.tf
+++ b/modules/lead/infrastructure/main.tf
@@ -12,10 +12,11 @@ module "system_namespace" {
 }
 
 module "system_issuer" {
-  source      = "../../common/cert-issuer"
-  namespace   = module.system_namespace.name
-  issuer_type = var.issuer_type
-  crd_waiter  = null_resource.cert_manager_crd_delay.id
+  source          = "../../common/cert-issuer"
+  namespace       = module.system_namespace.name
+  issuer_type     = var.issuer_type
+  crd_waiter      = null_resource.cert_manager_crd_delay.id
+  external_values = var.ondemand_toleration_values
 }
 
 resource "kubernetes_cluster_role" "tiller_cluster_role" {
@@ -287,5 +288,6 @@ module "opa" {
   source             = "../../common/opa"
   namespace          = module.system_namespace.name
   opa_failure_policy = var.opa_failure_policy
+  external_values    = var.ondemand_toleration_values
 }
 

--- a/modules/lead/infrastructure/metrics.tf
+++ b/modules/lead/infrastructure/metrics.tf
@@ -16,6 +16,8 @@ resource "helm_release" "metrics" {
     value = "--kubelet-preferred-address-types=InternalIP"
   }
 
+  values = [var.ondemand_toleration_values]
+
   depends_on = [kubernetes_cluster_role_binding.tiller_cluster_role_binding]
 }
 

--- a/modules/lead/infrastructure/prometheus.tf
+++ b/modules/lead/infrastructure/prometheus.tf
@@ -11,7 +11,7 @@ resource "helm_release" "prometheus" {
   timeout    = 600
   wait       = true
 
-  depends_on = [kubernetes_cluster_role_binding.tiller_cluster_role_binding]
+  values = [data.template_file.prometheus_values.rendered, var.ondemand_toleration_values]
 
-  values = [data.template_file.prometheus_values.rendered]
+  depends_on = [kubernetes_cluster_role_binding.tiller_cluster_role_binding]
 }

--- a/modules/lead/infrastructure/variables.tf
+++ b/modules/lead/infrastructure/variables.tf
@@ -22,3 +22,6 @@ variable "acme_dns_providers" {
 variable "issuer_type" {
 }
 
+variable "ondemand_toleration_values" {
+  default = ""
+}

--- a/stacks/environment-aws/eks.tf
+++ b/stacks/environment-aws/eks.tf
@@ -17,8 +17,7 @@ EOF
       asg_max_size          = var.asg_max_size
       bootstrap_extra_args  = "--enable-docker-bridge 'true'"
       key_name              = var.key_name
-      autoscaling_enabled   = true
-      protect_from_scale_in = true
+      autoscaling_enabled   = false
       pre_userdata          = local.ssm_init
       kubelet_extra_args    = "--node-labels=kubernetes.io/lifecycle=normal --register-with-taints=${var.ondemand_toleration_key}=true:NoSchedule"
     },
@@ -30,8 +29,7 @@ EOF
       asg_max_size          = var.asg_max_size
       bootstrap_extra_args  = "--enable-docker-bridge 'true'"
       key_name              = var.key_name
-      autoscaling_enabled   = true
-      protect_from_scale_in = true
+      autoscaling_enabled   = false
       pre_userdata          = local.ssm_init
       kubelet_extra_args    = "--node-labels=kubernetes.io/lifecycle=normal --register-with-taints=${var.ondemand_toleration_key}=true:NoSchedule"
     },
@@ -43,8 +41,7 @@ EOF
       asg_max_size          = var.asg_max_size
       bootstrap_extra_args  = "--enable-docker-bridge 'true'"
       key_name              = var.key_name
-      autoscaling_enabled   = true
-      protect_from_scale_in = true
+      autoscaling_enabled   = false
       pre_userdata          = local.ssm_init
       kubelet_extra_args    = "--node-labels=kubernetes.io/lifecycle=normal --register-with-taints=${var.ondemand_toleration_key}=true:NoSchedule"
     },   
@@ -60,6 +57,7 @@ EOF
       bootstrap_extra_args    = "--enable-docker-bridge 'true'"
       key_name                = var.key_name
       autoscaling_enabled     = true
+      protect_from_scale_in   = true
       pre_userdata            = local.ssm_init
       kubelet_extra_args      = "--node-labels=kubernetes.io/lifecycle=spot"
     }

--- a/stacks/environment-aws/lead.tf
+++ b/stacks/environment-aws/lead.tf
@@ -14,7 +14,8 @@ module "infrastructure" {
   enable_opa         = "false"
   issuer_type        = "acme"
 
-  external_dns_chart_values = data.template_file.external_dns_values.rendered
+  ondemand_toleration_values = data.template_file.ondemand_toleration.rendered
+  external_dns_chart_values  = data.template_file.external_dns_values.rendered
 
   providers = {
     helm = helm.system
@@ -44,7 +45,7 @@ resource "helm_release" "cluster_autoscaler" {
   wait       = true
   version    = "3.1.0"
 
-  values = [data.template_file.cluster_autoscaler.rendered]
+  values = [data.template_file.cluster_autoscaler.rendered, data.template_file.ondemand_toleration.rendered]
 
   provider = helm.system
 }

--- a/stacks/environment-aws/main.tf
+++ b/stacks/environment-aws/main.tf
@@ -29,6 +29,12 @@ provider "helm" {
   tiller_image    = "gcr.io/kubernetes-helm/tiller:v2.14.1"
   service_account = module.infrastructure.tiller_service_account
 
+  override = [
+    "spec.template.spec.tolerations[0].key=${var.ondemand_toleration_key}",
+    "spec.template.spec.tolerations[0].operator=Exists",
+    "spec.template.spec.tolerations[0].effect.NoSchedule"
+  ]
+  
   kubernetes {
     host                   = data.aws_eks_cluster.cluster.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
@@ -42,6 +48,12 @@ provider "helm" {
   namespace       = module.toolchain.namespace
   tiller_image    = "gcr.io/kubernetes-helm/tiller:v2.14.1"
   service_account = module.toolchain.tiller_service_account
+
+  override = [
+    "spec.template.spec.tolerations[0].key=${var.ondemand_toleration_key}",
+    "spec.template.spec.tolerations[0].operator=Exists",
+    "spec.template.spec.tolerations[0].effect.NoSchedule"
+  ]
 
   kubernetes {
     host                   = data.aws_eks_cluster.cluster.endpoint

--- a/stacks/environment-aws/variables.tf
+++ b/stacks/environment-aws/variables.tf
@@ -22,7 +22,7 @@ variable "key_name" {
 }
 
 variable "instance_type" {
-  default = "m5.large"
+  default = "t2.micro"
 }
 
 variable "asg_min_size" {
@@ -34,6 +34,27 @@ variable "asg_desired_capacity" {
 }
 
 variable "asg_max_size" {
+  default = "1"
+}
+
+variable "ondemand_toleration_key" {
+  default = "ScheduleOndemand"
+}
+
+variable "spot_instance_types" {
+  type    = list
+  default = ["m5.large", "c5.large", "m4.large", "c4.large", "t3.large", "r5.large"]
+}
+
+variable "spot_asg_min_size" {
+  default = "1"
+}
+
+variable "spot_asg_desired_capacity" {
+  default = "1"
+}
+
+variable "spot_asg_max_size" {
   default = "5"
 }
 

--- a/stacks/product-aws/main.tf
+++ b/stacks/product-aws/main.tf
@@ -14,6 +14,12 @@ provider "helm" {
   tiller_image    = "gcr.io/kubernetes-helm/tiller:v2.14.1"
   service_account = module.product.toolchain_service_account
 
+  override = [
+    "spec.template.spec.tolerations[0].key=${var.ondemand_toleration_key}",
+    "spec.template.spec.tolerations[0].operator=Exists",
+    "spec.template.spec.tolerations[0].effect.NoSchedule"
+  ]
+
   kubernetes {
     load_config_file = var.load_config_file
     config_context   = var.config_context
@@ -32,6 +38,12 @@ provider "helm" {
   tiller_image    = "gcr.io/kubernetes-helm/tiller:v2.14.1"
   service_account = module.product.staging_service_account
 
+  override = [
+    "spec.template.spec.tolerations[0].key=${var.ondemand_toleration_key}",
+    "spec.template.spec.tolerations[0].operator=Exists",
+    "spec.template.spec.tolerations[0].effect.NoSchedule"
+  ]
+
   kubernetes {
     load_config_file = var.load_config_file
     config_context   = var.config_context
@@ -49,6 +61,12 @@ provider "helm" {
   namespace       = module.product.production_namespace
   tiller_image    = "gcr.io/kubernetes-helm/tiller:v2.14.1"
   service_account = module.product.production_service_account
+
+  override = [
+    "tolerations[0].key=ScheduleOndemand",
+    "tolerations[0].operator=Exists",
+    "tolerations[0].effect.NoSchedule"
+  ]
 
   kubernetes {
     load_config_file = var.load_config_file

--- a/stacks/product-aws/variables.tf
+++ b/stacks/product-aws/variables.tf
@@ -28,3 +28,6 @@ variable "load_config_file" {
   default = false
 }
 
+variable "ondemand_toleration_key" {
+  default = "ScheduleOndemand"
+}


### PR DESCRIPTION
This builds upon ENG-626 and using tolerations/taints defined there to ensure tiller is installed to an ondemand node and not a spot node.  Furthermore, cluster-autoscaler is disabled for the ondemand node group.