### PR TITLE
Set idle time for skaffold pod

### DIFF
--- a/modules/lead/product/jenkins-values.tpl
+++ b/modules/lead/product/jenkins-values.tpl
@@ -99,6 +99,7 @@ master:
                         resourceLimitCpu: 256m
                         resourceRequestMemory: 128Mi
                         resourceLimitMemory: 256Mi
+                        idleMinutes: 60
                     envVars:
                       - envVar:
                           key: "SKAFFOLD_DEFAULT_REPO"


### PR DESCRIPTION
This allows for a pod to stick around to allow jenkins to have an
executor that can perform slack feedback quickly