### PR TITLE
Added linuxbrew compatibility

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,12 +1,9 @@
-cask_args appdir: "/Applications"
-tap "homebrew/cask"
-brew "terraform"
-brew "terragrunt"
-brew "kubernetes-cli"
-brew "kubernetes-helm"
-brew "aws-iam-authenticator"
-brew "azure-cli"
-brew "dnsmasq"
-brew "go"
-
-cask "aws-vault"
+# brew 'terraform'
+brew 'terragrunt'
+brew 'kubernetes-cli'
+brew 'kubernetes-helm'
+brew 'aws-iam-authenticator'
+brew 'azure-cli'
+brew 'dnsmasq'
+brew 'go'
+brew 'aws-vault'

--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,4 @@
-# brew 'terraform'
+brew 'terraform'
 brew 'terragrunt'
 brew 'kubernetes-cli'
 brew 'kubernetes-helm'
@@ -6,4 +6,11 @@ brew 'aws-iam-authenticator'
 brew 'azure-cli'
 brew 'dnsmasq'
 brew 'go'
-brew 'aws-vault'
+
+# If using Linuxbrew, install brew formula, otherwise use the macOS cask
+if `uname -s`.strip.eql?('Linux')
+  brew 'aws-vault'
+else
+  tap 'homebrew/cask'
+  cask 'aws-vault'
+end

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ This repository contains the Terraform automation to manage LEAD environments.
 - [Istio Implementation](docs/istio-implementation.md)
 
 ## Tools
-Install required tools with [Homebrew](https://brew.sh/):
+Install required tools with Homebrew [macOS](https://brew.sh/) or [Linux](https://docs.brew.sh/Homebrew-on-Linux):
 
-```
-brew bundle
+```SHELL
+brew bundle --verbose  # verosity to view installation process
 ```
 
 ## Setup


### PR DESCRIPTION
Issue: https://github.com/liatrio/lead-terraform/issues/101

Homebrew has [merged](https://github.com/Linuxbrew/brew#linuxbrew-has-been-merged-into-homebrew) with the Linuxbrew project.  This PR allows for Linux users who use homebrew to also take advantage of the Brewfile setup. 

In this case, casks are macOS specific.  This is why I changed `aws-vault` from a cask to a formula.  

I also updated the formula double quotes to single.  Brewfiles are _ruby_ based and single quotes are best practice. 