### PR TITLE
bump sdm_version in environment-local

### DIFF
--- a/stacks/environment-local/variables.tf
+++ b/stacks/environment-local/variables.tf
@@ -22,7 +22,7 @@ variable "opa_failure_policy" {
 }
 
 variable "sdm_version" {
-  default = "0.2.22"
+  default = "0.4.0-160-gd3913d2"
 }
 
 variable "product_version" {


### PR DESCRIPTION
Version 0.2.22 operator-toolchain charts don't exist anymore so terragrunt apply fails when running locally