### PR TITLE
fix: production rolebinding references staging namespace

### DIFF
--- a/modules/lead/product/production.tf
+++ b/modules/lead/product/production.tf
@@ -187,6 +187,6 @@ resource "kubernetes_role_binding" "default_production_rolebinding" {
   subject {
     kind      = "ServiceAccount"
     name      = "default"
-    namespace   = module.staging_namespace.name
+    namespace   = module.production_namespace.name
   }
 }


### PR DESCRIPTION
right now, production deployments will fail since the `initContainers` that run `kubectl wait` don't have permissions to get pods in the namespace. this is because the production rolebinding references the staging namespace for the subject, so the default service account in production has no permissions.