### PR TITLE
fix: don't use auth for keycloak SMTP locally, bump timeout to 15 seconds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ endif
 	git tag -a -m "releasing $(NEW_VERSION)" $(NEW_VERSION)
 	git push origin $(NEW_VERSION)
 
-TF_KEYCLOAK_VERSION = 1.10.0
+TF_KEYCLOAK_VERSION = 1.11.1
 TF_KEYCLOAK_PLATFORM = $(shell go env GOOS)_$(shell go env GOARCH)
 plugins: 
 	mkdir -p ~/.terraform.d/plugins

--- a/modules/lead/toolchain/keycloak.tf
+++ b/modules/lead/toolchain/keycloak.tf
@@ -44,6 +44,7 @@ provider "keycloak" {
   password      = var.keycloak_admin_password
   url           = "${local.protocol}://keycloak.${module.toolchain_namespace.name}.${var.cluster}.${var.root_zone_name}"
   initial_login = false
+  client_timeout = 15
 }
 
 # Give Keycloak API a chance to become responsive

--- a/modules/lead/toolchain/keycloak.tf
+++ b/modules/lead/toolchain/keycloak.tf
@@ -78,9 +78,14 @@ resource "keycloak_realm" "realm" {
     ssl      = false
     from     = var.smtp_from_email
     from_display_name = "Keycloak - ${var.root_zone_name} ${title(var.cluster)} ${title(var.namespace)}"
-    auth {
-      username = var.smtp_username
-      password = var.smtp_password
+
+    dynamic "auth" {
+      for_each = var.smtp_username == "" || var.smtp_password == "" ? [] : [1]
+
+      content {
+        username = var.smtp_username
+        password = var.smtp_password
+      }
     }
   }
 }


### PR DESCRIPTION
I'll have a more permanent fix when I get a response to https://github.com/hashicorp/terraform-plugin-sdk/issues/216.

The `client_timeout` provider attribute was added in 1.11, so I bumped that so it could be used since the instance of Keycloak running locally can be a bit slow at times.