### PR TITLE
[ENG-1195] bump cluster-autoscaler version to 6.0.1

### DIFF
--- a/stacks/environment-aws/lead.tf
+++ b/stacks/environment-aws/lead.tf
@@ -58,7 +58,7 @@ resource "helm_release" "cluster_autoscaler" {
   chart      = "cluster-autoscaler"
   timeout    = 600
   wait       = true
-  version    = "3.1.0"
+  version    = "6.0.1"
 
   values = [data.template_file.cluster_autoscaler.rendered, data.template_file.essential_toleration.rendered]
 


### PR DESCRIPTION
this appears to be the only task left for ENG-1195.  I believe that this will require a manual run of `helm del  --purge` before this can be deployed