### PR TITLE
[ENG 1195] allow EKS module to manage cluster autoscaler IAM without attaching to worker nodes

### DIFF
--- a/stacks/environment-aws/eks.tf
+++ b/stacks/environment-aws/eks.tf
@@ -104,7 +104,7 @@ resource "aws_security_group" "elb" {
 
 module "eks" {
   source                               = "terraform-aws-modules/eks/aws"
-  version                              = "6.0.2"
+  version                              = "7.0.0"
   cluster_version                      = "1.14"
   #cluster_enabled_log_types            = ["api","audit","authenticator","controllerManager","scheduler"]
   cluster_name                         = var.cluster

--- a/stacks/environment-aws/eks.tf
+++ b/stacks/environment-aws/eks.tf
@@ -104,7 +104,7 @@ resource "aws_security_group" "elb" {
 
 module "eks" {
   source                               = "terraform-aws-modules/eks/aws"
-  version                              = "6.0.0"
+  version                              = "6.0.2"
   cluster_version                      = "1.14"
   #cluster_enabled_log_types            = ["api","audit","authenticator","controllerManager","scheduler"]
   cluster_name                         = var.cluster
@@ -116,6 +116,8 @@ module "eks" {
   write_kubeconfig                     = false
   permissions_boundary                 = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/${aws_iam_policy.workspace_role_boundary.name}"
   manage_worker_iam_resources          = true
+  manage_worker_autoscaling_policy     = true
+  attach_worker_autoscaling_policy     = false
   worker_groups = [
     {
       name                  = "essential0"

--- a/stacks/environment-aws/eks.tf
+++ b/stacks/environment-aws/eks.tf
@@ -118,6 +118,11 @@ module "eks" {
   manage_worker_iam_resources          = true
   manage_worker_autoscaling_policy     = true
   attach_worker_autoscaling_policy     = false
+
+  workers_additional_policies = [
+    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  ]
+
   worker_groups = [
     {
       name                  = "essential0"
@@ -134,7 +139,6 @@ module "eks" {
       enabled_metrics       = ["GroupMinSize", "GroupMaxSize", "GroupDesiredCapacity", "GroupInServiceInstances", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
       pre_userdata          = local.ssm_init
       kubelet_extra_args    = "--node-labels=kubernetes.io/lifecycle=essential --register-with-taints=${var.essential_taint_key}=true:NoSchedule"
-      iam_instance_profile_name = aws_iam_instance_profile.worker_node_profile.name
     }
   ]
 

--- a/stacks/environment-aws/iam.tf
+++ b/stacks/environment-aws/iam.tf
@@ -8,62 +8,11 @@ resource "aws_iam_openid_connect_provider" "default" {
   thumbprint_list = ["9e99a48a9960b14926bb7f3b02e22da2b0ab7280"]
 }
 
-### Worker Node Permissions
-
-resource "aws_iam_role" "worker_node_role" {
-  name = "${var.cluster}_worker_node_role"
-  assume_role_policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Action": "sts:AssumeRole",
-            "Principal": {
-               "Service": "ec2.amazonaws.com"
-            },
-            "Effect": "Allow",
-            "Sid": ""
-        }
-    ]
-}
-EOF
-}
-
 ### DELETE ME once we have terragrunt using IAM role attachment
 resource "aws_iam_role_policy_attachment" "worker_operator_jenkins" {
   role = module.eks.worker_iam_role_name
   policy_arn = aws_iam_policy.operator_jenkins.arn
 }
-resource "aws_iam_role_policy_attachment" "worker_ssm" {
-  role = module.eks.worker_iam_role_name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-}
-
-resource "aws_iam_role_policy_attachment" "worker_ssm_role_attachment" {
-  role = aws_iam_role.worker_node_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-}
-
-resource "aws_iam_role_policy_attachment" "worker_eks_role_attachment" {
-  role = aws_iam_role.worker_node_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
-}
-
-resource "aws_iam_role_policy_attachment" "worker_ecr_role_attachment" {
-  role = aws_iam_role.worker_node_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
-}
-
-resource "aws_iam_role_policy_attachment" "worker_eks_cni_role_attachment" {
-  role = aws_iam_role.worker_node_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
-}
-
-resource "aws_iam_instance_profile" "worker_node_profile" {
-  role = "${aws_iam_role.worker_node_role.name}"
-}
-
-### End Worker Node Permissions
 
 resource "aws_iam_role" "external_dns_service_account" {
   name = "${var.cluster}_external_dns_service_account"

--- a/stacks/environment-aws/iam.tf
+++ b/stacks/environment-aws/iam.tf
@@ -197,49 +197,9 @@ resource "aws_iam_role" "cluster_autoscaler_service_account" {
 EOF
 }
 
-resource "aws_iam_policy" "cluster_autoscaler" {
-  name = "${var.cluster}-cluster-autoscaler"
-
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "eksWorkerAutoscalingAll",
-            "Effect": "Allow",
-            "Action": [
-                "ec2:DescribeLaunchTemplateVersions",
-                "autoscaling:DescribeTags",
-                "autoscaling:DescribeLaunchConfigurations",
-                "autoscaling:DescribeAutoScalingInstances",
-                "autoscaling:DescribeAutoScalingGroups"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Sid": "eksWorkerAutoscalingOwn",
-            "Effect": "Allow",
-            "Action": [
-                "autoscaling:UpdateAutoScalingGroup",
-                "autoscaling:TerminateInstanceInAutoScalingGroup",
-                "autoscaling:SetDesiredCapacity"
-            ],
-            "Resource": "*",
-            "Condition": {
-                "StringEquals": {
-                    "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/enabled": "true",
-                    "autoscaling:ResourceTag/kubernetes.io/cluster/${var.cluster}": "owned"
-                }
-            }
-        }
-    ]
-}
-EOF
-}
-
 resource "aws_iam_role_policy_attachment" "cluster_autoscaler" {
   role = aws_iam_role.cluster_autoscaler_service_account.name
-  policy_arn = aws_iam_policy.cluster_autoscaler.arn
+  policy_arn = module.eks.worker_autoscaling_policy_arn
 }
 
 resource "aws_iam_role" "operator_jenkins_service_account" {


### PR DESCRIPTION
version `6.0.2` for the eks module added variables `manage_worker_autoscaling_policy` and `attach_worker_autoscaling_policy` which allows us to have better control over how the cluster autoscaler IAM policy is defined / attached.

by setting `manage_worker_autoscaling_policy` to `true` and `attach_worker_autoscaling_policy` to `false`, the EKS module will still manage the contents of the policy for us without attaching it to the worker nodes, allowing us to attach it to the cluster autoscaler service account instead.