### PR TITLE
raise essential asg max -> 10

### DIFF
--- a/stacks/environment-aws/variables.tf
+++ b/stacks/environment-aws/variables.tf
@@ -51,7 +51,7 @@ variable "essential_asg_desired_capacity" {
 }
 
 variable "essential_asg_max_size" {
-  default = "5"
+  default = "10"
 }
 
 variable "essential_instance_type" {


### PR DESCRIPTION
we run out of resources to schedule converge jobs really quickly with only 5 x t3.small instances. i think 10 is a better default here