### PR TITLE
do not persist agent pods

### DIFF
--- a/modules/lead/product/jenkins-values.tpl
+++ b/modules/lead/product/jenkins-values.tpl
@@ -125,7 +125,6 @@ master:
                         resourceLimitCpu: 256m
                         resourceRequestMemory: 128Mi
                         resourceLimitMemory: 256Mi
-                    idleMinutes: 60
                     envVars:
                       - envVar:
                           key: "SKAFFOLD_DEFAULT_REPO"


### PR DESCRIPTION
This gets around the artifactory permission error by non persisting the image cacheing on the agent and forcing rebuild.

Downside is consecutive builds may take longer.