### PR TITLE
Add DeleteObject to operator-jenkins policy

### DIFF
--- a/stacks/environment-aws/iam.tf
+++ b/stacks/environment-aws/iam.tf
@@ -241,7 +241,8 @@ resource "aws_iam_policy" "operator_jenkins" {
      "Effect": "Allow",
      "Action": [
                 "s3:PutObject",
-                "s3:GetObject"
+                "s3:GetObject",
+                "s3:DeleteObject"
      ],
      "Resource": ["arn:aws:s3:::lead-sdm-operators-${data.aws_caller_identity.current.account_id}-${var.cluster}.liatr.io/*"]
    },


### PR DESCRIPTION
Allow the IAM role to delete objects in the specified s3 bucket