### PR TITLE
ignore_changes for artifactory helm release

### DIFF
--- a/modules/lead/toolchain/artifactory.tf
+++ b/modules/lead/toolchain/artifactory.tf
@@ -153,5 +153,15 @@ resource "helm_release" "artifactory" {
   }
 
   values = [data.template_file.artifactory_values.rendered]
+
+  # We would like to ignore changes on artifactory.persistence.size, but currently there's
+  # a limitation in Terraform because set members are not individually addressible
+  # (see https://github.com/hashicorp/terraform/issues/22504), so we're just ignoring
+  # all changes for Artifactory. Alternative is to do the configuration of the PVC
+  # separately and point the chart to the existing PVC.
+  lifecycle {
+    ignore_changes = all
+  }
+
 }
 


### PR DESCRIPTION
I'm proposing that we `ignore_changes` for the Artifactory helm release. If we do make changes like expand a volume, this causes issues for re-applying the helm configuration. Additionally, if we wanted to do something like upgrade the Artifactory version while retaining the existing data, we would likely not do that through Helm.