### PR TITLE
update cert-issuer module to work with GCP DNS

### DIFF
--- a/modules/common/cert-issuer/helm/cert-manager-issuers/templates/issuer.yaml
+++ b/modules/common/cert-issuer/helm/cert-manager-issuers/templates/issuer.yaml
@@ -26,6 +26,13 @@ spec:
             hostedZoneID: {{ .Values.acme.dnsProvider.route53.hostedZoneID }}
             role: {{ .Values.acme.dnsProvider.route53.role }}
 {{- end}}
+{{- if eq .Values.acme.dnsProvider.type "gcp" }}
+          clouddns:
+            project: {{ .Values.acme.dnsProvider.gcp.project }}
+            serviceAccountSecretRef:
+              name: {{ .Values.acme.dnsProvider.gcp.serviceAccountSecretName }}
+              key: {{ .Values.acme.dnsProvider.gcp.serviceAccountSecretKey }}
+{{- end}}
 {{- end}}
 {{- end}}
 {{- if .Values.ca.enabled }}

--- a/modules/common/cert-issuer/helm/cert-manager-issuers/values.yaml
+++ b/modules/common/cert-issuer/helm/cert-manager-issuers/values.yaml
@@ -10,6 +10,10 @@ acme:
     route53:
       region: us-east-1
       hostedZoneID: foo
+    gcp:
+      project:
+      serviceAccountSecretName:
+      serviceAccountSecretKey:
   solver: dns
 ca:
   enabled: false

--- a/modules/common/cert-issuer/issuer-values.tpl
+++ b/modules/common/cert-issuer/issuer-values.tpl
@@ -2,7 +2,7 @@ issuerName: ${issuer_name}
 acme:
   enabled: ${ issuer_type == "acme" }
   server: ${ issuer_server }
-  email: cloudservices@liatr.io
+  email: ${ issuer_email }
   httpProvider:
     ingressClass: ${provider_http_ingress_class}
   dnsProvider:

--- a/modules/common/cert-issuer/issuer-values.tpl
+++ b/modules/common/cert-issuer/issuer-values.tpl
@@ -10,6 +10,10 @@ acme:
     route53:
       region: ${route53_dns_region}
       hostedZoneID: ${route53_dns_hosted_zone}
+    gcp:
+      project: ${gcp_dns_project}
+	  serviceAccountSecretName: ${gcp_dns_service_account_secret_name}
+	  serviceAccountSecretKey: ${gcp_dns_service_account_secret_key}
   solver: ${acme_solver}
 ca:
   enabled: ${issuer_type == "ca"}

--- a/modules/common/cert-issuer/main.tf
+++ b/modules/common/cert-issuer/main.tf
@@ -2,17 +2,20 @@ data "template_file" "issuer_values" {
   template = file("${path.module}/issuer-values.tpl")
 
   vars = {
-    issuer_name                 = var.issuer_name
-    issuer_server               = var.issuer_server
-    issuer_email                = var.issuer_email
-    acme_solver                 = var.acme_solver
-    provider_http_ingress_class = var.provider_http_ingress_class
-    provider_dns_type           = var.provider_dns_type
-    route53_dns_region          = var.route53_dns_region
-    route53_dns_hosted_zone     = var.route53_dns_hosted_zone
-    issuer_type                 = var.issuer_type
-    crd_waiter                  = var.crd_waiter # this enforces a dependency on the cert-manager CRDs
-    ca_secret                   = var.ca_secret
+    issuer_name                         = var.issuer_name
+    issuer_server                       = var.issuer_server
+    issuer_email                        = var.issuer_email
+    acme_solver                         = var.acme_solver
+    provider_http_ingress_class         = var.provider_http_ingress_class
+    provider_dns_type                   = var.provider_dns_type
+    route53_dns_region                  = var.route53_dns_region
+    route53_dns_hosted_zone             = var.route53_dns_hosted_zone
+    gcp_dns_project                     = var.gcp_dns_project
+    gcp_dns_service_account_secret_name = var.gcp_dns_service_account_secret_name
+    gcp_dns_service_account_secret_key  = var.gcp_dns_service_account_secret_key
+    issuer_type                         = var.issuer_type
+    crd_waiter                          = var.crd_waiter # this enforces a dependency on the cert-manager CRDs
+    ca_secret                           = var.ca_secret
   }
 }
 

--- a/modules/common/cert-issuer/main.tf
+++ b/modules/common/cert-issuer/main.tf
@@ -4,6 +4,7 @@ data "template_file" "issuer_values" {
   vars = {
     issuer_name                 = var.issuer_name
     issuer_server               = var.issuer_server
+    issuer_email                = var.issuer_email
     acme_solver                 = var.acme_solver
     provider_http_ingress_class = var.provider_http_ingress_class
     provider_dns_type           = var.provider_dns_type

--- a/modules/common/cert-issuer/variables.tf
+++ b/modules/common/cert-issuer/variables.tf
@@ -34,6 +34,18 @@ variable "route53_dns_hosted_zone" {
   default = ""
 }
 
+variable "gcp_dns_project" {
+  default = ""
+}
+
+variable "gcp_dns_service_account_secret_name" {
+  default = ""
+}
+
+variable "gcp_dns_service_account_secret_key" {
+  default = ""
+}
+
 variable "enabled" {
   default = true
 }

--- a/modules/common/cert-issuer/variables.tf
+++ b/modules/common/cert-issuer/variables.tf
@@ -10,6 +10,10 @@ variable "issuer_server" {
   default = "https://acme-v02.api.letsencrypt.org/directory"
 }
 
+variable "issuer_email" {
+  default = "cloudservices@liatr.io"
+}
+
 variable "acme_solver" {
   default = "http"
 }

--- a/modules/common/istio/main.tf
+++ b/modules/common/istio/main.tf
@@ -143,7 +143,7 @@ resource "kubernetes_secret" "gcp_dns_service_account_key" {
   }
 
   data = {
-    local.gcp_service_account_secret_key = var.gcp_dns_service_account_json
+    (local.gcp_service_account_secret_key) = var.gcp_dns_service_account_json
   }
 }
 
@@ -163,7 +163,7 @@ module "istio_cert_issuer" {
   route53_dns_hosted_zone = var.route53_zone_id
 
   gcp_dns_project = var.gcp_dns_project
-  gcp_dns_service_account_secret_name = var.cert_issuer_dns_provider == "gcp" ? kubernetes_secret.gcp_dns_service_account_key[0].metadata.name : ""
+  gcp_dns_service_account_secret_name = var.cert_issuer_dns_provider == "gcp" ? kubernetes_secret.gcp_dns_service_account_key[0].metadata[0].name : ""
   gcp_dns_service_account_secret_key = local.gcp_service_account_secret_key
 }
 

--- a/modules/common/istio/main.tf
+++ b/modules/common/istio/main.tf
@@ -135,7 +135,7 @@ resource "kubernetes_cluster_role_binding" "tiller_cluster_role_binding" {
 }
 
 resource "kubernetes_secret" "gcp_dns_service_account_key" {
-  count = var.cert_issuer_dns_provider == "clouddns" ? 1 : 0
+  count = var.cert_issuer_dns_provider == "gcp" ? 1 : 0
 
   metadata {
     name = "gcp-dns-service-account-key"
@@ -163,7 +163,7 @@ module "istio_cert_issuer" {
   route53_dns_hosted_zone = var.route53_zone_id
 
   gcp_dns_project = var.gcp_dns_project
-  gcp_dns_service_account_secret_name = var.cert_issuer_dns_provider == "clouddns" ? kubernetes_secret.gcp_dns_service_account_key[0].metadata.name : ""
+  gcp_dns_service_account_secret_name = var.cert_issuer_dns_provider == "gcp" ? kubernetes_secret.gcp_dns_service_account_key[0].metadata.name : ""
   gcp_dns_service_account_secret_key = local.gcp_service_account_secret_key
 }
 

--- a/modules/common/istio/main.tf
+++ b/modules/common/istio/main.tf
@@ -1,3 +1,7 @@
+locals {
+  gcp_service_account_secret_key = "credentials.json"
+}
+
 module "istio_namespace" {
   source    = "../namespace"
   enabled   = var.enabled
@@ -130,6 +134,19 @@ resource "kubernetes_cluster_role_binding" "tiller_cluster_role_binding" {
   }
 }
 
+resource "kubernetes_secret" "gcp_dns_service_account_key" {
+  count = var.cert_issuer_dns_provider == "clouddns" ? 1 : 0
+
+  metadata {
+    name = "gcp-dns-service-account-key"
+    namespace = module.istio_namespace.name
+  }
+
+  data = {
+    local.gcp_service_account_secret_key = var.gcp_dns_service_account_json
+  }
+}
+
 module "istio_cert_issuer" {
   source        = "../cert-issuer"
   enabled       = var.enabled
@@ -140,9 +157,14 @@ module "istio_cert_issuer" {
   crd_waiter    = var.crd_waiter
 
   acme_solver             = "dns"
-  provider_dns_type       = "route53"
-  route53_dns_region      = var.region
-  route53_dns_hosted_zone = var.zone_id
+  provider_dns_type       = var.cert_issuer_dns_provider
+
+  route53_dns_region      = var.route53_region
+  route53_dns_hosted_zone = var.route53_zone_id
+
+  gcp_dns_project = var.gcp_dns_project
+  gcp_dns_service_account_secret_name = var.cert_issuer_dns_provider == "clouddns" ? kubernetes_secret.gcp_dns_service_account_key[0].metadata.name : ""
+  gcp_dns_service_account_secret_key = local.gcp_service_account_secret_key
 }
 
 module "istio_flagger" {

--- a/modules/common/istio/variables.tf
+++ b/modules/common/istio/variables.tf
@@ -1,8 +1,6 @@
 variable "namespace" {}
 variable "crd_waiter" {}
-variable "region" {}
 variable "domain" {}
-variable "zone_id" {}
 
 variable "kiali_username" {
   default = "admin"
@@ -18,6 +16,26 @@ variable "cert_issuer_server" {
 
 variable "cert_issuer_name" {
   default = "letsencrypt-dns"
+}
+
+variable "cert_issuer_dns_provider" {
+  default = "route53"
+}
+
+variable "route53_zone_id" {
+  default = ""
+}
+
+variable "route53_region" {
+  default = ""
+}
+
+variable "gcp_dns_project" {
+  default = ""
+}
+
+variable "gcp_dns_service_account_json" {
+  default = ""
 }
 
 variable "enabled" {

--- a/stacks/environment-aws/istio.tf
+++ b/stacks/environment-aws/istio.tf
@@ -28,8 +28,9 @@ module "istio_system" {
   enabled    = var.enable_istio
   namespace  = "istio-system"
   crd_waiter = null_resource.istio_init_delay.id
-  region     = var.region
-  zone_id    = aws_route53_zone.cluster_zone.zone_id
+  cert_issuer_dns_provider = "route53"
+  route53_region     = var.region
+  route53_zone_id    = aws_route53_zone.cluster_zone.zone_id
   domain     = "istio-system.${module.eks.cluster_id}.${var.root_zone_name}"
   providers = {
     helm = helm.system

--- a/stacks/environment-local/istio.tf
+++ b/stacks/environment-local/istio.tf
@@ -27,8 +27,6 @@ module "istio_system" {
   enabled    = var.enable_istio
   namespace  = "istio-system"
   crd_waiter = null_resource.istio_init_delay.id
-  region     = ""
-  zone_id    = ""
   domain     = "istio-system.${var.cluster}.${var.root_zone_name}"
   providers = {
     helm = helm.system


### PR DESCRIPTION
I need this to run cert-manager locally with my personal domain which uses GCP CloudDNS