### PR TITLE
set default max resources in limit ranges

### DIFF
--- a/modules/common/namespace/main.tf
+++ b/modules/common/namespace/main.tf
@@ -10,7 +10,7 @@ resource "kubernetes_namespace" "ns" {
 resource "kubernetes_limit_range" "resource-limits" {
   count = var.enabled ? 1 : 0
   metadata {
-    name = "namespace-resource-limits"
+    name      = "namespace-resource-limits"
     namespace = kubernetes_namespace.ns[0].metadata[0].name
   }
   spec {
@@ -23,6 +23,10 @@ resource "kubernetes_limit_range" "resource-limits" {
       default = {
         cpu    = var.resource_limit_cpu
         memory = var.resource_limit_memory
+      }
+      max = {
+        cpu    = var.resource_max_cpu
+        memory = var.resource_max_memory
       }
     }
   }
@@ -65,23 +69,23 @@ resource "kubernetes_role" "tiller_role" {
   }
   rule {
     api_groups = ["networking.istio.io"]
-    resources = ["*"]
-    verbs = ["get", "create", "watch", "delete", "list", "patch"]
+    resources  = ["*"]
+    verbs      = ["get", "create", "watch", "delete", "list", "patch"]
   }
   rule {
     api_groups = ["autoscaling"]
-    resources = ["horizontalpodautoscalers"]
-    verbs = ["*"]
+    resources  = ["horizontalpodautoscalers"]
+    verbs      = ["*"]
   }
   rule {
     api_groups = ["flagger.app"]
-    resources = ["canaries","canaries/status"]
-    verbs = ["*"]
+    resources  = ["canaries", "canaries/status"]
+    verbs      = ["*"]
   }
   rule {
     api_groups = [""]
-    resources = ["secrets"]
-    verbs = ["get", "create"]
+    resources  = ["secrets"]
+    verbs      = ["get", "create"]
   }
 }
 

--- a/modules/common/namespace/variables.tf
+++ b/modules/common/namespace/variables.tf
@@ -34,3 +34,13 @@ variable "resource_limit_memory" {
   type    = string
   default = "512Mi"
 }
+
+variable "resource_max_cpu" {
+  type    = string
+  default = "2"
+}
+
+variable "resource_max_memory" {
+  type    = string
+  default = "7.5Gi"
+}


### PR DESCRIPTION
setting a max on limits and requests protects us from killing pods by accidentally requesting amounts larger than allocatable by a node and sets limits for VPAs to scale to.