### PR TITLE
change limit range max mem from Gi to Mi

### DIFF
--- a/modules/common/namespace/variables.tf
+++ b/modules/common/namespace/variables.tf
@@ -42,5 +42,5 @@ variable "resource_max_cpu" {
 
 variable "resource_max_memory" {
   type    = string
-  default = "7.5Gi"
+  default = "7680Mi"
 }


### PR DESCRIPTION
Change max mem limit range format to Mi instead of Gi so terraform doesn't try to reformat it