### PR TITLE
Add rules to policies for sparky import

### DIFF
--- a/modules/environment/aws/eks/iam.tf
+++ b/modules/environment/aws/eks/iam.tf
@@ -118,6 +118,11 @@ resource "aws_iam_role_policy" "workspace_role_policy" {
       "Resource": "*"
     },
     {
+      "Effect": "Allow",
+      "Action": "codecommit:GitPush",
+      "Resource": "*"
+    },
+    {
       "Action": [
         "ec2:ModifyVolume"
       ],

--- a/stacks/environment-aws/iam.tf
+++ b/stacks/environment-aws/iam.tf
@@ -155,6 +155,11 @@ resource "aws_iam_role_policy" "operator-slack" {
         "cloud9:DescribeEnvironmentMemberships", "cloud9:DescribeEnvironments"
       ],
       "Resource": ["*"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "codecommit:CreateRepository",
+      "Resource": "*"
     }
   ]
 }


### PR DESCRIPTION
Allows lead_operator_slack_service_account role to create codecommit repositores and allows lead_workspace_role to push to codecommit repositories