### PR TITLE
terraform configuration for google login via keycloak & keycloak test user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ else
 TF_VALIDATE_ARGS = ""
 endif
 
-validate: 
+validate:
 	@terraform init -backend=false stacks/environment-aws
 	@terraform validate $(TF_VALIDATE_ARGS) stacks/environment-aws
 	@terraform init -backend=false stacks/environment-local
@@ -32,7 +32,7 @@ validate:
 	@terraform validate $(TF_VALIDATE_ARGS) stacks/product-local
 
 %: environments/%
-	cd $< && terragrunt $(COMMAND) 
+	cd $< && terragrunt $(COMMAND)
 
 clean:
 	@find . -type d -name ".terragrunt-cache" -prune -exec rm -rf {} \;
@@ -59,17 +59,17 @@ endif
 	git tag -a -m "releasing $(NEW_VERSION)" $(NEW_VERSION)
 	git push origin $(NEW_VERSION)
 
-test: 
+test:
 	cd tests && go test liatr.io/lead-terraform/tests/local -timeout 90m -v --count=1
 
-test-aws: 
+test-aws:
 	cd tests && go test liatr.io/lead-terraform/tests/aws -timeout 90m -v --count=1
 
 test-aws-nodestroy:
 	cd tests && go test liatr.io/lead-terraform/tests/aws -timeout 90m -v --count=1 --destroyCluster=false
 
 build_keycloak_provider:
-TF_KEYCLOAK_VERSION = 1.11.1
+TF_KEYCLOAK_VERSION = 1.17.1
 TF_KEYCLOAK_PLATFORM = $(shell go env GOOS)_$(shell go env GOARCH)
 plugins:
 	mkdir -p ~/.terraform.d/plugins

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ test-aws-nodestroy:
 	cd tests && go test liatr.io/lead-terraform/tests/aws -timeout 90m -v --count=1 --destroyCluster=false
 
 build_keycloak_provider:
-TF_KEYCLOAK_VERSION = 1.17.1
+TF_KEYCLOAK_VERSION = 1.18.0
 TF_KEYCLOAK_PLATFORM = $(shell go env GOOS)_$(shell go env GOARCH)
 plugins:
 	mkdir -p ~/.terraform.d/plugins

--- a/modules/lead/toolchain/keycloak.tf
+++ b/modules/lead/toolchain/keycloak.tf
@@ -119,6 +119,20 @@ resource "keycloak_oidc_google_identity_provider" "google" {
   hosted_domain = "liatrio.com"
 }
 
+resource "keycloak_user" "test_user" {
+  count = var.enable_keycloak && var.enable_test_user ? 1 : 0
+
+  realm_id = keycloak_realm.realm[0].id
+  username = "casey"
+
+  initial_password {
+    value     = var.test_user_password
+    temporary = false
+  }
+
+  email_verified = true
+}
+
 resource "kubernetes_secret" "keycloak_toolchain_realm" {
   count      = var.enable_keycloak ? 1 : 0
   depends_on = [

--- a/modules/lead/toolchain/variables.tf
+++ b/modules/lead/toolchain/variables.tf
@@ -66,6 +66,8 @@ variable "crd_waiter" {
 variable "enable_google_login" {}
 variable "google_identity_provider_client_id" {}
 variable "google_identity_provider_client_secret" {}
+variable "enable_test_user" {}
+variable "test_user_password" {}
 
 variable "keycloak_admin_password" {
 }

--- a/modules/lead/toolchain/variables.tf
+++ b/modules/lead/toolchain/variables.tf
@@ -63,6 +63,10 @@ variable "enable_harbor" {
 variable "crd_waiter" {
 }
 
+variable "enable_google_login" {}
+variable "google_identity_provider_client_id" {}
+variable "google_identity_provider_client_secret" {}
+
 variable "keycloak_admin_password" {
 }
 

--- a/stacks/environment-aws/lead.tf
+++ b/stacks/environment-aws/lead.tf
@@ -98,6 +98,11 @@ data "aws_ssm_parameter" "google_identity_provider_client_secret" {
   name  = "/${var.cluster}/google_identity_provider_client_secret"
 }
 
+data "aws_ssm_parameter" "test_user_password" {
+  count = var.enable_test_user ? 1 : 0
+  name  = "/${var.cluster}/test_user_password"
+}
+
 
 module "toolchain" {
   source                                 = "../../modules/lead/toolchain"
@@ -112,6 +117,8 @@ module "toolchain" {
   enable_google_login                    = var.enable_google_login
   google_identity_provider_client_id     = var.enable_google_login ? data.aws_ssm_parameter.google_identity_provider_client_id[0].value : ""
   google_identity_provider_client_secret = var.enable_google_login ? data.aws_ssm_parameter.google_identity_provider_client_secret[0].value : ""
+  enable_test_user                       = var.enable_test_user
+  test_user_password                     = var.enable_test_user ? data.aws_ssm_parameter.test_user_password[0].value : ""
   enable_istio                           = var.enable_istio
   enable_artifactory                     = var.enable_artifactory
   enable_gitlab                          = var.enable_gitlab

--- a/stacks/environment-aws/lead.tf
+++ b/stacks/environment-aws/lead.tf
@@ -88,31 +88,44 @@ data "aws_ssm_parameter" "prometheus_slack_webhook_url" {
   name = "/${var.cluster}/prometheus_slack_webhook_url"
 }
 
+data "aws_ssm_parameter" "google_identity_provider_client_id" {
+  count = var.enable_google_login ? 1 : 0
+  name  = "/${var.cluster}/google_identity_provider_client_id"
+}
+
+data "aws_ssm_parameter" "google_identity_provider_client_secret" {
+  count = var.enable_google_login ? 1 : 0
+  name  = "/${var.cluster}/google_identity_provider_client_secret"
+}
+
 
 module "toolchain" {
-  source                     = "../../modules/lead/toolchain"
-  root_zone_name             = var.root_zone_name
-  cluster                    = module.eks.cluster_id
-  namespace                  = var.toolchain_namespace
-  image_whitelist            = var.image_whitelist
-  elb_security_group_id      = module.eks.aws_security_group_elb.id
-  artifactory_license        = data.aws_ssm_parameter.artifactory_license.value
-  keycloak_admin_password    = data.aws_ssm_parameter.keycloak_admin_password.value
-  keycloak_postgres_password = data.aws_ssm_parameter.keycloak_postgres_password.value
-  enable_istio               = var.enable_istio
-  enable_artifactory         = var.enable_artifactory
-  enable_gitlab              = var.enable_gitlab
-  enable_keycloak            = var.enable_keycloak
-  enable_mailhog             = var.enable_mailhog
-  enable_sonarqube           = var.enable_sonarqube
-  enable_xray                = var.enable_xray
-  enable_grafeas             = var.enable_grafeas
-  enable_harbor              = var.enable_harbor
-  issuer_name                = module.cluster_issuer.issuer_name
-  issuer_kind                = module.cluster_issuer.issuer_kind
-  crd_waiter                 = module.infrastructure.crd_waiter
-  grafeas_version            = var.grafeas_version
-  k8s_storage_class          = var.k8s_storage_class
+  source                                 = "../../modules/lead/toolchain"
+  root_zone_name                         = var.root_zone_name
+  cluster                                = module.eks.cluster_id
+  namespace                              = var.toolchain_namespace
+  image_whitelist                        = var.image_whitelist
+  elb_security_group_id                  = module.eks.aws_security_group_elb.id
+  artifactory_license                    = data.aws_ssm_parameter.artifactory_license.value
+  keycloak_admin_password                = data.aws_ssm_parameter.keycloak_admin_password.value
+  keycloak_postgres_password             = data.aws_ssm_parameter.keycloak_postgres_password.value
+  enable_google_login                    = var.enable_google_login
+  google_identity_provider_client_id     = var.enable_google_login ? data.aws_ssm_parameter.google_identity_provider_client_id[0].value : ""
+  google_identity_provider_client_secret = var.enable_google_login ? data.aws_ssm_parameter.google_identity_provider_client_secret[0].value : ""
+  enable_istio                           = var.enable_istio
+  enable_artifactory                     = var.enable_artifactory
+  enable_gitlab                          = var.enable_gitlab
+  enable_keycloak                        = var.enable_keycloak
+  enable_mailhog                         = var.enable_mailhog
+  enable_sonarqube                       = var.enable_sonarqube
+  enable_xray                            = var.enable_xray
+  enable_grafeas                         = var.enable_grafeas
+  enable_harbor                          = var.enable_harbor
+  issuer_name                            = module.cluster_issuer.issuer_name
+  issuer_kind                            = module.cluster_issuer.issuer_kind
+  crd_waiter                             = module.infrastructure.crd_waiter
+  grafeas_version                        = var.grafeas_version
+  k8s_storage_class                      = var.k8s_storage_class
 
   harbor_registry_disk_size    = "200Gi"
   harbor_chartmuseum_disk_size = "100Gi"

--- a/stacks/environment-aws/variables.tf
+++ b/stacks/environment-aws/variables.tf
@@ -108,6 +108,10 @@ variable "enable_google_login" {
   default = false
 }
 
+variable "enable_test_user" {
+  default = false
+}
+
 variable "enable_mailhog" {
   default = false
 }

--- a/stacks/environment-aws/variables.tf
+++ b/stacks/environment-aws/variables.tf
@@ -104,6 +104,10 @@ variable "enable_keycloak" {
   default = true
 }
 
+variable "enable_google_login" {
+  default = false
+}
+
 variable "enable_mailhog" {
   default = false
 }


### PR DESCRIPTION
when `enable_google_login` is true, google authentication will be added to the toolchain realm (used to be done in prod manually)

when `enable_test_user` is true, a test user named `casey` will be created in the toolchain realm (used to be done in sandbox manually)