### PR TITLE
add vault module to be consumed by shared service stack

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[{*.yml, *.yaml, *.tf}]
+[{*.yml, *.yaml, *.tf, *.tpl}]
 indent_size = 2
 
 [*.go]

--- a/modules/tools/vault/charts/vault-helm/.helmignore
+++ b/modules/tools/vault/charts/vault-helm/.helmignore
@@ -1,0 +1,4 @@
+.git/
+.terraform/
+bin/
+test/

--- a/modules/tools/vault/charts/vault-helm/Chart.yaml
+++ b/modules/tools/vault/charts/vault-helm/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: vault
+version: 0.5.0
+description: Install and configure Vault on Kubernetes.
+home: https://www.vaultproject.io
+icon: https://github.com/hashicorp/vault/raw/f22d202cde2018f9455dec755118a9b84586e082/Vault_PrimaryLogo_Black.png
+sources:
+  - https://github.com/hashicorp/vault
+  - https://github.com/hashicorp/vault-helm
+  - https://github.com/hashicorp/vault-k8s

--- a/modules/tools/vault/charts/vault-helm/README.md
+++ b/modules/tools/vault/charts/vault-helm/README.md
@@ -1,0 +1,41 @@
+Note: this folder (`vault-helm`) was directly cloned from https://github.com/hashicorp/vault-helm and all non-essential
+files were removed.
+
+# Vault Helm Chart
+
+This repository contains the official HashiCorp Helm chart for installing
+and configuring Vault on Kubernetes. This chart supports multiple use
+cases of Vault on Kubernetes depending on the values provided.
+
+For full documentation on this Helm chart along with all the ways you can
+use Vault with Kubernetes, please see the
+[Vault and Kubernetes documentation](https://www.vaultproject.io/docs/platform/k8s/).
+
+## Prerequisites
+
+To use the charts here, [Helm](https://helm.sh/) must be installed in your
+Kubernetes cluster. Setting up Kubernetes and Helm and is outside the scope
+of this README. Please refer to the Kubernetes and Helm documentation.
+
+The versions required are:
+
+  * **Helm 3.0+** - This is the earliest version of Helm tested. It is possible
+    it works with earlier versions but this chart is untested for those versions.
+  * **Kubernetes 1.9+** - This is the earliest version of Kubernetes tested.
+    It is possible that this chart works with earlier versions but it is
+    untested. Other versions verified are Kubernetes 1.10, 1.11.
+
+## Usage
+
+For now, we do not host a chart repository. To use the charts, you must
+download this repository and unpack it into a directory. Either
+[download a tagged release](https://github.com/hashicorp/vault-helm/releases) or
+use `git checkout` to a tagged release.
+Assuming this repository was unpacked into the directory `vault-helm`, the chart can
+then be installed directly:
+
+    helm install ./vault-helm
+
+Please see the many options supported in the `values.yaml`
+file. These are also fully documented directly on the
+[Vault website](https://www.vaultproject.io/docs/platform/k8s/helm).

--- a/modules/tools/vault/charts/vault-helm/templates/NOTES.txt
+++ b/modules/tools/vault/charts/vault-helm/templates/NOTES.txt
@@ -1,0 +1,14 @@
+
+Thank you for installing HashiCorp Vault!
+
+Now that you have deployed Vault, you should look over the docs on using
+Vault with Kubernetes available here:
+
+https://www.vaultproject.io/docs/
+
+
+Your release is named {{ .Release.Name }}. To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get {{ .Release.Name }}
+

--- a/modules/tools/vault/charts/vault-helm/templates/_helpers.tpl
+++ b/modules/tools/vault/charts/vault-helm/templates/_helpers.tpl
@@ -1,0 +1,355 @@
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to
+this (by the DNS naming spec). If release name contains chart name it will
+be used as a full name.
+*/}}
+{{- define "vault.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "vault.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "vault.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Compute the maximum number of unavailable replicas for the PodDisruptionBudget.
+This defaults to (n/2)-1 where n is the number of members of the server cluster.
+Add a special case for replicas=1, where it should default to 0 as well.
+*/}}
+{{- define "vault.pdb.maxUnavailable" -}}
+{{- if eq (int .Values.server.ha.replicas) 1 -}}
+{{ 0 }}
+{{- else if .Values.server.ha.disruptionBudget.maxUnavailable -}}
+{{ .Values.server.ha.disruptionBudget.maxUnavailable -}}
+{{- else -}}
+{{- div (sub (div (mul (int .Values.server.ha.replicas) 10) 2) 1) 10 -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Set the variable 'mode' to the server mode requested by the user to simplify
+template logic.
+*/}}
+{{- define "vault.mode" -}}
+  {{- if .Values.injector.externalVaultAddr -}}
+    {{- $_ := set . "mode" "external" -}}
+  {{- else if eq (.Values.server.dev.enabled | toString) "true" -}}
+    {{- $_ := set . "mode" "dev" -}}
+  {{- else if eq (.Values.server.ha.enabled | toString) "true" -}}
+    {{- $_ := set . "mode" "ha" -}}
+  {{- else if or (eq (.Values.server.standalone.enabled | toString) "true") (eq (.Values.server.standalone.enabled | toString) "-") -}}
+    {{- $_ := set . "mode" "standalone" -}}
+  {{- else -}}
+    {{- $_ := set . "mode" "" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Set's the replica count based on the different modes configured by user
+*/}}
+{{- define "vault.replicas" -}}
+  {{ if eq .mode "standalone" }}
+    {{- default 1 -}}
+  {{ else if eq .mode "ha" }}
+    {{- .Values.server.ha.replicas | default 3 -}}
+  {{ else }}
+    {{- default 1 -}}
+  {{ end }}
+{{- end -}}
+
+{{/*
+Set's up configmap mounts if this isn't a dev deployment and the user
+defined a custom configuration.  Additionally iterates over any
+extra volumes the user may have specified (such as a secret with TLS).
+*/}}
+{{- define "vault.volumes" -}}
+  {{- if and (ne .mode "dev") (or (ne .Values.server.standalone.config "")  (ne .Values.server.ha.config "")) }}
+        - name: config
+          configMap:
+            name: {{ template "vault.fullname" . }}-config
+  {{ end }}
+  {{- range .Values.server.extraVolumes }}
+        - name: userconfig-{{ .name }}
+          {{ .type }}:
+          {{- if (eq .type "configMap") }}
+            name: {{ .name }}
+          {{- else if (eq .type "secret") }}
+            secretName: {{ .name }}
+          {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Set's a command to override the entrypoint defined in the image
+so we can make the user experience nicer.  This works in with
+"vault.args" to specify what commands /bin/sh should run.
+*/}}
+{{- define "vault.command" -}}
+  {{ if or (eq .mode "standalone") (eq .mode "ha") }}
+          - "/bin/sh"
+          - "-ec"
+  {{ end }}
+{{- end -}}
+
+{{/*
+Set's the args for custom command to render the Vault configuration
+file with IP addresses to make the out of box experience easier
+for users looking to use this chart with Consul Helm.
+*/}}
+{{- define "vault.args" -}}
+  {{ if or (eq .mode "standalone") (eq .mode "ha") }}
+          - |
+            sed -E "s/HOST_IP/${HOST_IP?}/g" /vault/config/extraconfig-from-values.hcl > /tmp/storageconfig.hcl;
+            sed -Ei "s/POD_IP/${POD_IP?}/g" /tmp/storageconfig.hcl;
+            /usr/local/bin/docker-entrypoint.sh vault server -config=/tmp/storageconfig.hcl {{ .Values.server.extraArgs }}
+  {{ end }}
+{{- end -}}
+
+{{/*
+Set's additional environment variables based on the mode.
+*/}}
+{{- define "vault.envs" -}}
+  {{ if eq .mode "dev" }}
+            - name: VAULT_DEV_ROOT_TOKEN_ID
+              value: "root"
+  {{ end }}
+{{- end -}}
+
+{{/*
+Set's which additional volumes should be mounted to the container
+based on the mode configured.
+*/}}
+{{- define "vault.mounts" -}}
+  {{ if eq (.Values.server.auditStorage.enabled | toString) "true" }}
+            - name: audit
+              mountPath: /vault/audit
+  {{ end }}
+  {{ if or (eq .mode "standalone") (and (eq .mode "ha") (eq (.Values.server.ha.raft.enabled | toString) "true"))  }}
+    {{ if eq (.Values.server.dataStorage.enabled | toString) "true" }}
+            - name: data
+              mountPath: /vault/data
+    {{ end }}
+  {{ end }}
+  {{ if and (ne .mode "dev") (or (ne .Values.server.standalone.config "")  (ne .Values.server.ha.config "")) }}
+            - name: config
+              mountPath: /vault/config
+  {{ end }}
+  {{- range .Values.server.extraVolumes }}
+            - name: userconfig-{{ .name }}
+              readOnly: true
+              mountPath: {{ .path | default "/vault/userconfig" }}/{{ .name }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Set's up the volumeClaimTemplates when data or audit storage is required.  HA
+might not use data storage since Consul is likely it's backend, however, audit
+storage might be desired by the user.
+*/}}
+{{- define "vault.volumeclaims" -}}
+  {{- if and (ne .mode "dev") (or .Values.server.dataStorage.enabled .Values.server.auditStorage.enabled) }}
+  volumeClaimTemplates:
+      {{- if and (eq (.Values.server.dataStorage.enabled | toString) "true") (or (eq .mode "standalone") (eq (.Values.server.ha.raft.enabled | toString ) "true" )) }}
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - {{ .Values.server.dataStorage.accessMode | default "ReadWriteOnce" }}
+        resources:
+          requests:
+            storage: {{ .Values.server.dataStorage.size }}
+          {{- if .Values.server.dataStorage.storageClass }}
+        storageClassName: {{ .Values.server.dataStorage.storageClass }}
+          {{- end }}
+      {{ end }}
+      {{- if eq (.Values.server.auditStorage.enabled | toString) "true" }}
+    - metadata:
+        name: audit
+      spec:
+        accessModes:
+          - {{ .Values.server.auditStorage.accessMode | default "ReadWriteOnce" }}
+        resources:
+          requests:
+            storage: {{ .Values.server.auditStorage.size }}
+          {{- if .Values.server.auditStorage.storageClass }}
+        storageClassName: {{ .Values.server.auditStorage.storageClass }}
+          {{- end }}
+      {{ end }}
+  {{ end }}
+{{- end -}}
+
+{{/*
+Set's the affinity for pod placement when running in standalone and HA modes.
+*/}}
+{{- define "vault.affinity" -}}
+  {{- if and (ne .mode "dev") .Values.server.affinity }}
+      affinity:
+        {{ tpl .Values.server.affinity . | nindent 8 | trim }}
+  {{ end }}
+{{- end -}}
+
+{{/*
+Sets the injector affinity for pod placement
+*/}}
+{{- define "injector.affinity" -}}
+  {{- if .Values.injector.affinity }}
+      affinity:
+        {{ tpl .Values.injector.affinity . | nindent 8 | trim }}
+  {{ end }}
+{{- end -}}
+
+{{/*
+Set's the toleration for pod placement when running in standalone and HA modes.
+*/}}
+{{- define "vault.tolerations" -}}
+  {{- if and (ne .mode "dev") .Values.server.tolerations }}
+      tolerations:
+        {{ tpl .Values.server.tolerations . | nindent 8 | trim }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Sets the injector toleration for pod placement
+*/}}
+{{- define "injector.tolerations" -}}
+  {{- if .Values.injector.tolerations }}
+      tolerations:
+        {{ tpl .Values.injector.tolerations . | nindent 8 | trim }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Set's the node selector for pod placement when running in standalone and HA modes.
+*/}}
+{{- define "vault.nodeselector" -}}
+  {{- if and (ne .mode "dev") .Values.server.nodeSelector }}
+      nodeSelector:
+        {{ tpl .Values.server.nodeSelector . | indent 8 | trim }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Sets the injector node selector for pod placement
+*/}}
+{{- define "injector.nodeselector" -}}
+  {{- if .Values.injector.nodeSelector }}
+      nodeSelector:
+        {{ tpl .Values.injector.nodeSelector . | indent 8 | trim }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Sets extra pod annotations
+*/}}
+{{- define "vault.annotations" -}}
+  {{- if and (ne .mode "dev") .Values.server.annotations }}
+      annotations:
+        {{- tpl .Values.server.annotations . | nindent 8 }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Sets extra ui service annotations
+*/}}
+{{- define "vault.ui.annotations" -}}
+  {{- if .Values.ui.annotations }}
+  annotations:
+    {{- tpl .Values.ui.annotations . | nindent 4 }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Sets extra service account annotations
+*/}}
+{{- define "vault.serviceAccount.annotations" -}}
+  {{- if and (ne .mode "dev") .Values.server.serviceAccount.annotations }}
+  annotations:
+    {{- tpl .Values.server.serviceAccount.annotations . | nindent 4 }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Sets extra ingress annotations
+*/}}
+{{- define "vault.ingress.annotations" -}}
+  {{- if .Values.server.ingress.annotations }}
+  annotations:
+    {{- tpl .Values.server.ingress.annotations . | nindent 4 }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Set's the container resources if the user has set any.
+*/}}
+{{- define "vault.resources" -}}
+  {{- if .Values.server.resources -}}
+          resources:
+{{ toYaml .Values.server.resources | indent 12}}
+  {{ end }}
+{{- end -}}
+
+{{/*
+Sets the container resources if the user has set any.
+*/}}
+{{- define "injector.resources" -}}
+  {{- if .Values.injector.resources -}}
+          resources:
+{{ toYaml .Values.injector.resources | indent 12}}
+  {{ end }}
+{{- end -}}
+
+{{/*
+Inject extra environment vars in the format key:value, if populated
+*/}}
+{{- define "vault.extraEnvironmentVars" -}}
+{{- if .extraEnvironmentVars -}}
+{{- range $key, $value := .extraEnvironmentVars }}
+- name: {{ printf "%s" $key | replace "." "_" | upper | quote }}
+  value: {{ $value | quote }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Inject extra environment populated by secrets, if populated
+*/}}
+{{- define "vault.extraSecretEnvironmentVars" -}}
+{{- if .extraSecretEnvironmentVars -}}
+{{- range .extraSecretEnvironmentVars }}
+- name: {{ .envName }}
+  valueFrom:
+   secretKeyRef:
+     name: {{ .secretName }}
+     key: {{ .secretKey }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Scheme for health check and local endpoint */}}
+{{- define "vault.scheme" -}}
+{{- if .Values.global.tlsDisable -}}
+{{ "http" }}
+{{- else -}}
+{{ "https" }}
+{{- end -}}
+{{- end -}}

--- a/modules/tools/vault/charts/vault-helm/templates/injector-clusterrole.yaml
+++ b/modules/tools/vault/charts/vault-helm/templates/injector-clusterrole.yaml
@@ -1,0 +1,18 @@
+{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "vault.fullname" . }}-agent-injector-clusterrole
+  labels:
+    app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations"]
+  verbs: 
+    - "get"
+    - "list"
+    - "watch"
+    - "patch"
+{{ end }}

--- a/modules/tools/vault/charts/vault-helm/templates/injector-clusterrolebinding.yaml
+++ b/modules/tools/vault/charts/vault-helm/templates/injector-clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "vault.fullname" . }}-agent-injector-binding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "vault.fullname" . }}-agent-injector-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: {{ template "vault.fullname" . }}-agent-injector
+  namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/modules/tools/vault/charts/vault-helm/templates/injector-deployment.yaml
+++ b/modules/tools/vault/charts/vault-helm/templates/injector-deployment.yaml
@@ -1,0 +1,104 @@
+{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") }}
+# Deployment for the injector
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "vault.fullname" . }}-agent-injector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    component: webhook
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "vault.name" . }}-agent-injector
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      component: webhook
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ template "vault.name" . }}-agent-injector
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        component: webhook
+    spec:
+      {{ template "injector.affinity" . }}
+      {{ template "injector.tolerations" . }}
+      {{ template "injector.nodeselector" . }}
+      serviceAccountName: "{{ template "vault.fullname" . }}-agent-injector"
+      securityContext:
+        runAsNonRoot: true
+        runAsGroup: {{ .Values.injector.gid | default 1000 }}
+        runAsUser: {{ .Values.injector.uid | default 100 }}
+      containers:
+        - name: sidecar-injector
+          {{ template "injector.resources" . }}
+          image: "{{ .Values.injector.image.repository }}:{{ .Values.injector.image.tag }}"
+          imagePullPolicy: "{{ .Values.injector.image.pullPolicy }}"
+          env:
+            - name: AGENT_INJECT_LISTEN
+              value: ":8080"
+            - name: AGENT_INJECT_LOG_LEVEL
+              value: {{ .Values.injector.logLevel | default "info" }}
+            - name: AGENT_INJECT_VAULT_ADDR
+            {{- if .Values.injector.externalVaultAddr }}
+              value: "{{ .Values.injector.externalVaultAddr }}"
+            {{- else }}
+              value: {{ include "vault.scheme" . }}://{{ template "vault.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.server.service.port }}
+            {{- end }}
+            - name: AGENT_INJECT_VAULT_AUTH_PATH
+              value: {{ .Values.injector.authPath }}
+            - name: AGENT_INJECT_VAULT_IMAGE
+              value: "{{ .Values.injector.agentImage.repository }}:{{ .Values.injector.agentImage.tag }}"
+            {{- if .Values.injector.certs.secretName }}
+            - name: AGENT_INJECT_TLS_CERT_FILE
+              value: "/etc/webhook/certs/{{ .Values.injector.certs.certName }}"
+            - name: AGENT_INJECT_TLS_KEY_FILE
+              value: "/etc/webhook/certs/{{ .Values.injector.certs.keyName }}"
+            {{- else }}
+            - name: AGENT_INJECT_TLS_AUTO
+              value: {{ template "vault.fullname" . }}-agent-injector-cfg
+            - name: AGENT_INJECT_TLS_AUTO_HOSTS
+              value: {{ template "vault.fullname" . }}-agent-injector-svc,{{ template "vault.fullname" . }}-agent-injector-svc.{{ .Release.Namespace }},{{ template "vault.fullname" . }}-agent-injector-svc.{{ .Release.Namespace }}.svc
+            {{- end }}
+            - name: AGENT_INJECT_LOG_FORMAT
+              value: {{ .Values.injector.logFormat | default "standard" }}
+            - name: AGENT_INJECT_REVOKE_ON_SHUTDOWN
+              value: "{{ .Values.injector.revokeOnShutdown | default false }}"
+            {{- include "vault.extraEnvironmentVars" .Values.injector | nindent 12 }}
+          args:
+            - agent-inject
+            - 2>&1
+          livenessProbe:
+            httpGet:
+              path: /health/ready
+              port: 8080
+              scheme: HTTPS
+            failureThreshold: 2
+            initialDelaySeconds: 1
+            periodSeconds: 2
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 8080
+              scheme: HTTPS
+            failureThreshold: 2
+            initialDelaySeconds: 2
+            periodSeconds: 2
+            successThreshold: 1
+            timeoutSeconds: 5
+{{- if .Values.injector.certs.secretName }}
+          volumeMounts:
+            - name: webhook-certs
+              mountPath: /etc/webhook/certs
+              readOnly: true
+      volumes:
+        - name: webhook-certs
+          secret:
+            secretName: "{{ .Values.injector.certs.secretName }}"
+{{- end }}
+{{ end }}

--- a/modules/tools/vault/charts/vault-helm/templates/injector-mutating-webhook.yaml
+++ b/modules/tools/vault/charts/vault-helm/templates/injector-mutating-webhook.yaml
@@ -1,0 +1,27 @@
+{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ template "vault.fullname" . }}-agent-injector-cfg
+  labels:
+    app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+webhooks:
+  - name: vault.hashicorp.com
+    clientConfig:
+      service:
+        name: {{ template "vault.fullname" . }}-agent-injector-svc
+        namespace: {{ .Release.Namespace }}
+        path: "/mutate"
+      caBundle: {{ .Values.injector.certs.caBundle }}
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+{{- if .Values.injector.namespaceSelector }}
+    namespaceSelector:
+{{ toYaml .Values.injector.namespaceSelector | indent 6}}
+{{ end }}
+{{ end }}

--- a/modules/tools/vault/charts/vault-helm/templates/injector-service.yaml
+++ b/modules/tools/vault/charts/vault-helm/templates/injector-service.yaml
@@ -1,0 +1,19 @@
+{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "vault.fullname" . }}-agent-injector-svc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  ports:
+  - port: 443
+    targetPort: 8080
+  selector:
+    app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    component: webhook
+{{- end }}

--- a/modules/tools/vault/charts/vault-helm/templates/injector-serviceaccount.yaml
+++ b/modules/tools/vault/charts/vault-helm/templates/injector-serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "vault.fullname" . }}-agent-injector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ end }}

--- a/modules/tools/vault/charts/vault-helm/templates/server-clusterrolebinding.yaml
+++ b/modules/tools/vault/charts/vault-helm/templates/server-clusterrolebinding.yaml
@@ -1,0 +1,23 @@
+{{ template "vault.mode" . }}
+{{- if ne .mode "external" }}
+{{- if and (ne .mode "") (and (eq (.Values.global.enabled | toString) "true") (eq (.Values.server.authDelegator.enabled | toString) "true")) }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "vault.fullname" . }}-server-binding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: {{ template "vault.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{ end }}
+{{ end }}

--- a/modules/tools/vault/charts/vault-helm/templates/server-config-configmap.yaml
+++ b/modules/tools/vault/charts/vault-helm/templates/server-config-configmap.yaml
@@ -1,0 +1,27 @@
+{{ template "vault.mode" . }}
+{{- if ne .mode "external" }}
+{{- if and (eq (.Values.global.enabled | toString) "true") (ne .mode "dev") -}}
+{{ if or (ne .Values.server.standalone.config "")  (ne .Values.server.ha.config "") -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "vault.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  extraconfig-from-values.hcl: |-
+    disable_mlock = true
+  {{- if eq .mode "standalone" }}
+    {{ tpl .Values.server.standalone.config . | nindent 4 | trim }}
+  {{- else if and (eq .mode "ha") (eq (.Values.server.ha.raft.enabled | toString) "false") }}
+    {{ tpl .Values.server.ha.config . | nindent 4 | trim }}
+  {{- else if and (eq .mode "ha") (eq (.Values.server.ha.raft.enabled | toString) "true") }}
+    {{ tpl .Values.server.ha.raft.config . | nindent 4 | trim }}
+  {{ end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/modules/tools/vault/charts/vault-helm/templates/server-discovery-role.yaml
+++ b/modules/tools/vault/charts/vault-helm/templates/server-discovery-role.yaml
@@ -1,0 +1,19 @@
+{{ template "vault.mode" . }}
+{{- if ne .mode "external" }}
+{{- if and (eq .mode "ha" ) (eq (.Values.global.enabled | toString) "true") }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ template "vault.fullname" . }}-discovery-role
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "list", "update", "patch"]
+{{ end }}
+{{ end }}

--- a/modules/tools/vault/charts/vault-helm/templates/server-discovery-rolebinding.yaml
+++ b/modules/tools/vault/charts/vault-helm/templates/server-discovery-rolebinding.yaml
@@ -1,0 +1,23 @@
+{{ template "vault.mode" . }}
+{{- if ne .mode "external" }}
+{{- if and (eq .mode "ha" ) (eq (.Values.global.enabled | toString) "true") }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ template "vault.fullname" . }}-discovery-rolebinding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "vault.fullname" . }}-discovery-role
+subjects:
+- kind: ServiceAccount
+  name: {{ template "vault.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{ end }}
+{{ end }}

--- a/modules/tools/vault/charts/vault-helm/templates/server-disruptionbudget.yaml
+++ b/modules/tools/vault/charts/vault-helm/templates/server-disruptionbudget.yaml
@@ -1,0 +1,24 @@
+{{ template "vault.mode" . }}
+{{- if ne .mode "external" -}}
+{{- if and (and (eq (.Values.global.enabled | toString) "true") (eq .mode "ha")) (eq (.Values.server.ha.disruptionBudget.enabled | toString) "true") -}}
+# PodDisruptionBudget to prevent degrading the server cluster through
+# voluntary cluster changes.
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "vault.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  maxUnavailable: {{ template "vault.pdb.maxUnavailable" . }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "vault.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      component: server
+{{- end -}}
+{{- end -}}

--- a/modules/tools/vault/charts/vault-helm/templates/server-ha-active-service.yaml
+++ b/modules/tools/vault/charts/vault-helm/templates/server-ha-active-service.yaml
@@ -1,0 +1,35 @@
+{{ template "vault.mode" . }}
+{{- if ne .mode "external" }}
+{{- if and (eq .mode "ha" ) (and (eq (.Values.server.service.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true")) }}
+# Service for active Vault pod
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "vault.fullname" . }}-active
+  namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+{{- if .Values.server.service.annotations }}
+{{ toYaml .Values.server.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  ports:
+    - name: http
+      port: 8200
+      targetPort: 8200
+    - name: internal
+      port: 8201
+      targetPort: 8201
+  selector:
+    app.kubernetes.io/name: {{ include "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    component: server
+    vault-active: "true"
+{{- end }}
+{{- end }}

--- a/modules/tools/vault/charts/vault-helm/templates/server-ha-standby-service.yaml
+++ b/modules/tools/vault/charts/vault-helm/templates/server-ha-standby-service.yaml
@@ -1,0 +1,35 @@
+{{ template "vault.mode" . }}
+{{- if ne .mode "external" }}
+{{- if and (eq .mode "ha" ) (and (eq (.Values.server.service.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true")) }}
+# Service for active Vault pod
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "vault.fullname" . }}-standby
+  namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+{{- if .Values.server.service.annotations }}
+{{ toYaml .Values.server.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  ports:
+    - name: http
+      port: 8200
+      targetPort: 8200
+    - name: internal
+      port: 8201
+      targetPort: 8201
+  selector:
+    app.kubernetes.io/name: {{ include "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    component: server
+    vault-active: "false"
+{{- end }}
+{{- end }}

--- a/modules/tools/vault/charts/vault-helm/templates/server-headless-service.yaml
+++ b/modules/tools/vault/charts/vault-helm/templates/server-headless-service.yaml
@@ -1,0 +1,35 @@
+{{ template "vault.mode" . }}
+{{- if ne .mode "external" }}
+{{- if and (eq (.Values.server.service.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") }}
+# Service for Vault cluster
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "vault.fullname" . }}-internal
+  namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+{{- if .Values.server.service.annotations }}
+{{ tpl .Values.server.service.annotations . | indent 4 }}
+{{- end }}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: "{{ include "vault.scheme" . }}"
+      port: {{ .Values.server.service.port }}
+      targetPort: {{ .Values.server.service.targetPort }}
+    - name: https-internal
+      port: 8201
+      targetPort: 8201
+  selector:
+    app.kubernetes.io/name: {{ include "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    component: server
+{{- end }}
+{{- end }}

--- a/modules/tools/vault/charts/vault-helm/templates/server-ingress.yaml
+++ b/modules/tools/vault/charts/vault-helm/templates/server-ingress.yaml
@@ -1,0 +1,44 @@
+{{ template "vault.mode" . }}
+{{- if ne .mode "external" }}
+{{- if .Values.server.ingress.enabled -}}
+{{- $serviceName := include "vault.fullname" . -}}
+{{- $servicePort := .Values.server.service.port -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "vault.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.server.ingress.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- template "vault.ingress.annotations" . }}
+spec:
+{{- if .Values.server.ingress.tls }}
+  tls:
+  {{- range .Values.server.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.server.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range (.paths | default (list "/")) }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+        {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/modules/tools/vault/charts/vault-helm/templates/server-service.yaml
+++ b/modules/tools/vault/charts/vault-helm/templates/server-service.yaml
@@ -1,0 +1,48 @@
+{{ template "vault.mode" . }}
+{{- if ne .mode "external" }}
+{{- if and (eq (.Values.server.service.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") }}
+# Service for Vault cluster
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "vault.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    # This must be set in addition to publishNotReadyAddresses due
+    # to an open issue where it may not work:
+    # https://github.com/kubernetes/kubernetes/issues/58662
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+{{- if .Values.server.service.annotations }}
+{{ tpl .Values.server.service.annotations . | indent 4 }}
+{{- end }}
+spec:
+  {{- if .Values.server.service.type}}
+  type: {{ .Values.server.service.type }}
+  {{- end}}
+  {{- if .Values.server.service.clusterIP }}
+  clusterIP: {{ .Values.server.service.clusterIP }}
+  {{- end }}
+  # We want the servers to become available even if they're not ready
+  # since this DNS is also used for join operations.
+  publishNotReadyAddresses: true
+  ports:
+    - name: {{ include "vault.scheme" . }}
+      port: {{ .Values.server.service.port }}
+      targetPort: {{ .Values.server.service.targetPort }}
+      {{- if and (.Values.server.service.nodePort) (eq (.Values.server.service.type | toString) "NodePort") }}
+      nodePort: {{ .Values.server.service.nodePort }}
+      {{- end }}
+    - name: https-internal
+      port: 8201
+      targetPort: 8201
+  selector:
+    app.kubernetes.io/name: {{ include "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    component: server
+{{- end }}
+{{- end }}

--- a/modules/tools/vault/charts/vault-helm/templates/server-serviceaccount.yaml
+++ b/modules/tools/vault/charts/vault-helm/templates/server-serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{ template "vault.mode" . }}
+{{- if ne .mode "external" }}
+{{- if and (ne .mode "") (eq (.Values.global.enabled | toString) "true") }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "vault.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{ template "vault.serviceAccount.annotations" . }}
+{{ end }}
+{{ end }}

--- a/modules/tools/vault/charts/vault-helm/templates/server-statefulset.yaml
+++ b/modules/tools/vault/charts/vault-helm/templates/server-statefulset.yaml
@@ -1,0 +1,158 @@
+{{ template "vault.mode" . }}
+{{- if ne .mode "external" }}
+{{- if and (ne .mode "") (eq (.Values.global.enabled | toString) "true") }}
+# StatefulSet to run the actual vault server cluster.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "vault.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  serviceName: {{ template "vault.fullname" . }}-internal
+  podManagementPolicy: Parallel
+  replicas: {{ template "vault.replicas" . }}
+  updateStrategy:
+    type: {{ .Values.server.updateStrategyType }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "vault.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      component: server
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: {{ template "vault.chart" . }}
+        app.kubernetes.io/name: {{ template "vault.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        component: server
+        {{- if  .Values.server.extraLabels -}}
+          {{- toYaml .Values.server.extraLabels | nindent 8 -}}
+        {{- end -}}
+      {{ template "vault.annotations" . }}
+    spec:
+      {{ template "vault.affinity" . }}
+      {{ template "vault.tolerations" . }}
+      {{ template "vault.nodeselector" . }}
+      terminationGracePeriodSeconds: 10
+      serviceAccountName: {{ template "vault.fullname" . }}
+      {{ if  .Values.server.shareProcessNamespace }}
+      shareProcessNamespace: true
+      {{ end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsGroup: {{ .Values.server.gid | default 1000 }}
+        runAsUser: {{ .Values.server.uid | default 100 }}
+        fsGroup: {{ .Values.server.gid | default 1000 }}
+      volumes:
+        {{ template "vault.volumes" . }}
+      containers:
+        - name: vault
+          {{ template "vault.resources" . }}
+          image: {{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default "latest" }}
+          imagePullPolicy: {{ .Values.server.image.pullPolicy }}
+          command: {{ template "vault.command" . }}
+          args: {{ template "vault.args" . }}
+          env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: VAULT_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: VAULT_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: VAULT_ADDR
+              value: "{{ include "vault.scheme" . }}://127.0.0.1:8200"
+            - name: VAULT_API_ADDR
+              value: "{{ include "vault.scheme" . }}://$(POD_IP):8200"
+            - name: SKIP_CHOWN
+              value: "true"
+            - name: SKIP_SETCAP
+              value: "true"
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: VAULT_CLUSTER_ADDR
+              value: "https://$(HOSTNAME).{{ template "vault.fullname" . }}-internal:8201"
+            {{ template "vault.envs" . }}
+            {{- include "vault.extraEnvironmentVars" .Values.server | nindent 12 }}
+            {{- include "vault.extraSecretEnvironmentVars" .Values.server | nindent 12 }}
+          volumeMounts:
+          {{ template "vault.mounts" . }}
+          ports:
+            - containerPort: 8200
+              name: {{ include "vault.scheme" . }}
+            - containerPort: 8201
+              name: https-internal
+            - containerPort: 8202
+              name: {{ include "vault.scheme" . }}-rep
+          {{- if .Values.server.readinessProbe.enabled }}
+          readinessProbe:
+            {{- if .Values.server.readinessProbe.path }}
+            httpGet:
+              path: {{ .Values.server.readinessProbe.path | quote }}
+              port: 8200
+              scheme: {{ include "vault.scheme" . | upper }}
+            {{- else }}
+            # Check status; unsealed vault servers return 0
+            # The exit code reflects the seal status:
+            #   0 - unsealed
+            #   1 - error
+            #   2 - sealed
+            exec:
+              command: ["/bin/sh", "-ec", "vault status -tls-skip-verify"]
+            {{- end }}
+            failureThreshold: 2
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            successThreshold: 1
+            timeoutSeconds: 5
+          {{- end }}
+          {{- if .Values.server.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.server.livenessProbe.path | quote }}
+              port: 8200
+              scheme: {{ include "vault.scheme" . | upper }}
+            initialDelaySeconds: {{ .Values.server.livenessProbe.initialDelaySeconds }}
+            periodSeconds: 3
+            successThreshold: 1
+            timeoutSeconds: 5
+          {{- end }}
+          lifecycle:
+            # Vault container doesn't receive SIGTERM from Kubernetes
+            # and after the grace period ends, Kube sends SIGKILL.  This
+            # causes issues with graceful shutdowns such as deregistering itself
+            # from Consul (zombie services).
+            preStop:
+              exec:
+                command: [
+                  "/bin/sh", "-c",
+                  # Adding a sleep here to give the pod eviction a
+                  # chance to propagate, so requests will not be made
+                  # to this pod while it's terminating
+                  "sleep {{ .Values.server.preStopSleepSeconds }} && kill -SIGTERM $(pidof vault)",
+                ]
+        {{- if .Values.server.extraContainers }}
+          {{ toYaml .Values.server.extraContainers | nindent 8}}
+        {{- end }}
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
+      {{- end }}
+  {{ template "vault.volumeclaims" . }}
+{{ end }}
+{{ end }}

--- a/modules/tools/vault/charts/vault-helm/templates/ui-service.yaml
+++ b/modules/tools/vault/charts/vault-helm/templates/ui-service.yaml
@@ -1,0 +1,47 @@
+{{ template "vault.mode" . }}
+{{- if ne .mode "external" }}
+{{- if and (ne .mode "") (eq (.Values.global.enabled | toString) "true") }}
+{{- if eq (.Values.ui.enabled | toString) "true" }}
+# Headless service for Vault server DNS entries. This service should only
+# point to Vault servers. For access to an agent, one should assume that
+# the agent is installed locally on the node and the NODE_IP should be used.
+# If the node can't run a Vault agent, then this service can be used to
+# communicate directly to a server agent.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "vault.fullname" . }}-ui
+  namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}-ui
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- template "vault.ui.annotations" . }}
+spec:
+  selector:
+    app.kubernetes.io/name: {{ include "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    component: server
+  publishNotReadyAddresses: true
+  ports:
+    - name: {{ include "vault.scheme" . }}
+      port: {{ .Values.ui.externalPort }}
+      targetPort: 8200
+      {{- if .Values.ui.serviceNodePort }}
+      nodePort: {{ .Values.ui.serviceNodePort }}
+      {{- end }}
+  type: {{ .Values.ui.serviceType }}
+  {{- if and (eq (.Values.ui.serviceType | toString) "LoadBalancer") (.Values.ui.loadBalancerSourceRanges) }}
+  loadBalancerSourceRanges:
+    {{- range $cidr := .Values.ui.loadBalancerSourceRanges }}
+      - {{ $cidr }}
+    {{- end }}
+  {{- end }}
+  {{- if and (eq (.Values.ui.serviceType | toString) "LoadBalancer") (.Values.ui.loadBalancerIP) }}
+  loadBalancerIP: {{ .Values.ui.loadBalancerIP }}
+  {{- end }}
+{{- end -}}
+
+{{ end }}
+{{ end }}

--- a/modules/tools/vault/charts/vault-helm/values.yaml
+++ b/modules/tools/vault/charts/vault-helm/values.yaml
@@ -1,0 +1,429 @@
+# Available parameters and their default values for the Vault chart.
+
+global:
+  # enabled is the master enabled switch. Setting this to true or false
+  # will enable or disable all the components within this chart by default.
+  enabled: true
+  # Image pull secret to use for registry authentication.
+  imagePullSecrets: []
+  # imagePullSecrets:
+  #   - name: image-pull-secret
+  # TLS for end-to-end encrypted transport
+  tlsDisable: true
+
+injector:
+  # True if you want to enable vault agent injection.
+  enabled: true
+
+  # External vault server address for the injector to use. Setting this will
+  # disable deployment of a vault server along with the injector.
+  externalVaultAddr: ""
+
+  # image sets the repo and tag of the vault-k8s image to use for the injector.
+  image:
+    repository: "hashicorp/vault-k8s"
+    tag: "0.3.0"
+    pullPolicy: IfNotPresent
+
+  # agentImage sets the repo and tag of the Vault image to use for the Vault Agent
+  # containers.  This should be set to the official Vault image.  Vault 1.3.1+ is
+  # required.
+  agentImage:
+    repository: "vault"
+    tag: "1.4.0"
+
+  # Mount Path of the Vault Kubernetes Auth Method.
+  authPath: "auth/kubernetes"
+
+  # Configures the log verbosity of the injector. Supported log levels: Trace, Debug, Error, Warn, Info
+  logLevel: "info"
+
+  # Configures the log format of the injector. Supported log formats: "standard", "json".
+  logFormat: "standard"
+  
+  # Configures all Vault Agent sidecars to revoke their token when shutting down
+  revokeOnShutdown: false
+
+  # namespaceSelector is the selector for restricting the webhook to only
+  # specific namespaces.
+  # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
+  # for more details.
+  # Example:
+  # namespaceSelector:
+  #    matchLabels:
+  #      sidecar-injector: enabled
+  namespaceSelector: {}
+
+  certs:
+    # secretName is the name of the secret that has the TLS certificate and
+    # private key to serve the injector webhook. If this is null, then the
+    # injector will default to its automatic management mode that will assign
+    # a service account to the injector to generate its own certificates.
+    secretName: null
+
+    # caBundle is a base64-encoded PEM-encoded certificate bundle for the
+    # CA that signed the TLS certificate that the webhook serves. This must
+    # be set if secretName is non-null.
+    caBundle: ""
+
+    # certName and keyName are the names of the files within the secret for
+    # the TLS cert and private key, respectively. These have reasonable
+    # defaults but can be customized if necessary.
+    certName: tls.crt
+    keyName: tls.key
+
+  resources: {}
+  # resources:
+  #   requests:
+  #     memory: 256Mi
+  #     cpu: 250m
+  #   limits:
+  #     memory: 256Mi
+  #     cpu: 250m
+
+  # extraEnvironmentVars is a list of extra enviroment variables to set in the
+  # injector deployment.
+  extraEnvironmentVars: {}
+    # KUBERNETES_SERVICE_HOST: kubernetes.default.svc
+
+  # Affinity Settings for injector pods
+  # This should be a multi-line string matching the affinity section of a
+  # PodSpec.
+  affinity: null
+
+  # Toleration Settings for injector pods
+  # This should be a multi-line string matching the Toleration array
+  # in a PodSpec.
+  tolerations: null
+
+  # nodeSelector labels for injector pod assignment, formatted as a muli-line string.
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  # Example:
+  # nodeSelector: |
+  #   beta.kubernetes.io/arch: amd64
+  nodeSelector: null
+
+server:
+  # Resource requests, limits, etc. for the server cluster placement. This
+  # should map directly to the value of the resources field for a PodSpec.
+  # By default no direct resource request is made.
+
+  image:
+    repository: "vault"
+    tag: "1.4.0"
+    # Overrides the default Image Pull Policy
+    pullPolicy: IfNotPresent
+
+  # Configure the Update Strategy Type for the StatefulSet
+  # See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+  updateStrategyType: "OnDelete"
+
+  resources:
+  # resources:
+  #   requests:
+  #     memory: 256Mi
+  #     cpu: 250m
+  #   limits:
+  #     memory: 256Mi
+  #     cpu: 250m
+
+  # Ingress allows ingress services to be created to allow external access
+  # from Kubernetes to access Vault pods.
+  ingress:
+    enabled: false
+    labels: {}
+      # traffic: external
+    annotations: {}
+      # |
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    hosts:
+      - host: chart-example.local
+        paths: []
+
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
+
+  # authDelegator enables a cluster role binding to be attached to the service
+  # account.  This cluster role binding can be used to setup Kubernetes auth
+  # method.  https://www.vaultproject.io/docs/auth/kubernetes.html
+  authDelegator:
+    enabled: true
+
+  # extraContainers is a list of sidecar containers. Specified as a raw YAML string.
+  extraContainers: null
+
+  # shareProcessNamespace enables process namespace sharing between Vault and the extraContainers
+  # This is useful if Vault must be signaled, e.g. to send a SIGHUP for log rotation
+  shareProcessNamespace: false
+
+  # extraArgs is a string containing additional Vault server arguments.
+  extraArgs: ""
+
+  # Used to define custom readinessProbe settings
+  readinessProbe:
+    enabled: true
+    # If you need to use a http path instead of the default exec
+    # path: /v1/sys/health?standbyok=true
+  # Used to enable a livenessProbe for the pods
+  livenessProbe:
+    enabled: false
+    path: "/v1/sys/health?standbyok=true"
+    initialDelaySeconds: 60
+
+  # Used to set the sleep time during the preStop step
+  preStopSleepSeconds: 5
+
+  # extraEnvironmentVars is a list of extra enviroment variables to set with the stateful set. These could be
+  # used to include variables required for auto-unseal.
+  extraEnvironmentVars: {}
+    # GOOGLE_REGION: global
+    # GOOGLE_PROJECT: myproject
+    # GOOGLE_APPLICATION_CREDENTIALS: /vault/userconfig/myproject/myproject-creds.json
+
+  # extraSecretEnvironmentVars is a list of extra enviroment variables to set with the stateful set.
+  # These variables take value from existing Secret objects.
+  extraSecretEnvironmentVars: []
+    # - envName: AWS_SECRET_ACCESS_KEY
+    #   secretName: vault
+    #   secretKey: AWS_SECRET_ACCESS_KEY
+
+  # extraVolumes is a list of extra volumes to mount. These will be exposed
+  # to Vault in the path `/vault/userconfig/<name>/`. The value below is
+  # an array of objects, examples are shown below.
+  extraVolumes: []
+    # - type: secret (or "configMap")
+    #   name: my-secret
+    #   path: null # default is `/vault/userconfig`
+
+  # Affinity Settings
+  # Commenting out or setting as empty the affinity variable, will allow
+  # deployment to single node services such as Minikube
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ template "vault.name" . }}
+              app.kubernetes.io/instance: "{{ .Release.Name }}"
+              component: server
+          topologyKey: kubernetes.io/hostname
+
+  # Toleration Settings for server pods
+  # This should be a multi-line string matching the Toleration array
+  # in a PodSpec.
+  tolerations: {}
+
+  # nodeSelector labels for server pod assignment, formatted as a muli-line string.
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  # Example:
+  # nodeSelector: |
+  #   beta.kubernetes.io/arch: amd64
+  nodeSelector: {}
+
+  # Extra labels to attach to the server pods
+  # This should be a multi-line string mapping directly to the a map of
+  # the labels to apply to the server pods
+  extraLabels: {}
+
+  # Extra annotations to attach to the server pods
+  # This should be a multi-line string mapping directly to the a map of
+  # the annotations to apply to the server pods
+  annotations: {}
+
+  # Enables a headless service to be used by the Vault Statefulset
+  service:
+    enabled: true
+    # clusterIP controls whether a Cluster IP address is attached to the
+    # Vault service within Kubernetes.  By default the Vault service will
+    # be given a Cluster IP address, set to None to disable.  When disabled
+    # Kubernetes will create a "headless" service.  Headless services can be
+    # used to communicate with pods directly through DNS instead of a round robin
+    # load balancer.
+    # clusterIP: None
+
+    # Configures the service type for the main Vault service.  Can be ClusterIP
+    # or NodePort.
+    #type: ClusterIP
+
+    # If type is set to "NodePort", a specific nodePort value can be configured,
+    # will be random if left blank.
+    #nodePort: 30000
+
+    # Port on which Vault server is listening
+    port: 8200
+    # Target port to which the service should be mapped to
+    targetPort: 8200
+    # Extra annotations for the service definition. This should be a multi-line
+    # string formatted as a map of the annotations to apply to the service.
+    annotations: {}
+
+  # This configures the Vault Statefulset to create a PVC for data
+  # storage when using the file or raft backend storage engines.
+  # See https://www.vaultproject.io/docs/configuration/storage/index.html to know more
+  dataStorage:
+    enabled: true
+    # Size of the PVC created
+    size: 10Gi
+    # Name of the storage class to use.  If null it will use the
+    # configured default Storage Class.
+    storageClass: null
+    # Access Mode of the storage device being used for the PVC
+    accessMode: ReadWriteOnce
+
+  # This configures the Vault Statefulset to create a PVC for audit
+  # logs.  Once Vault is deployed, initialized and unseal, Vault must
+  # be configured to use this for audit logs.  This will be mounted to
+  # /vault/audit
+  # See https://www.vaultproject.io/docs/audit/index.html to know more
+  auditStorage:
+    enabled: false
+    # Size of the PVC created
+    size: 10Gi
+    # Name of the storage class to use.  If null it will use the
+    # configured default Storage Class.
+    storageClass: null
+    # Access Mode of the storage device being used for the PVC
+    accessMode: ReadWriteOnce
+
+  # Run Vault in "dev" mode. This requires no further setup, no state management,
+  # and no initialization. This is useful for experimenting with Vault without
+  # needing to unseal, store keys, et. al. All data is lost on restart - do not
+  # use dev mode for anything other than experimenting.
+  # See https://www.vaultproject.io/docs/concepts/dev-server.html to know more
+  dev:
+    enabled: false
+
+  # Run Vault in "standalone" mode. This is the default mode that will deploy if
+  # no arguments are given to helm. This requires a PVC for data storage to use
+  # the "file" backend.  This mode is not highly available and should not be scaled
+  # past a single replica.
+  standalone:
+    enabled: "-"
+
+    # config is a raw string of default configuration when using a Stateful
+    # deployment. Default is to use a PersistentVolumeClaim mounted at /vault/data
+    # and store data there. This is only used when using a Replica count of 1, and
+    # using a stateful set. This should be HCL.
+    config: |
+      ui = true
+
+      listener "tcp" {
+        tls_disable = 1
+        address = "[::]:8200"
+        cluster_address = "[::]:8201"
+      }
+      storage "file" {
+        path = "/vault/data"
+      }
+
+      # Example configuration for using auto-unseal, using Google Cloud KMS. The
+      # GKMS keys must already exist, and the cluster must have a service account
+      # that is authorized to access GCP KMS.
+      #seal "gcpckms" {
+      #   project     = "vault-helm-dev"
+      #   region      = "global"
+      #   key_ring    = "vault-helm-unseal-kr"
+      #   crypto_key  = "vault-helm-unseal-key"
+      #}
+
+  # Run Vault in "HA" mode. There are no storage requirements unless audit log
+  # persistence is required.  In HA mode Vault will configure itself to use Consul
+  # for its storage backend.  The default configuration provided will work the Consul
+  # Helm project by default.  It is possible to manually configure Vault to use a
+  # different HA backend.
+  ha:
+    enabled: false
+    replicas: 3
+    
+    # Enables Vault's integrated Raft storage.  Unlike the typical HA modes where 
+    # Vault's persistence is external (such as Consul), enabling Raft mode will create 
+    # persistent volumes for Vault to store data according to the configuration under server.dataStorage.
+    # The Vault cluster will coordinate leader elections and failovers internally.
+    raft:
+      
+      # Enables Raft integrated storage
+      enabled: false
+      config: |
+        ui = true
+
+        listener "tcp" {
+          tls_disable = 1
+          address = "[::]:8200"
+          cluster_address = "[::]:8201"
+        }
+
+        storage "raft" {
+          path = "/vault/data"
+        }
+
+        service_registration "kubernetes" {}
+    # config is a raw string of default configuration when using a Stateful
+    # deployment. Default is to use a Consul for its HA storage backend.
+    # This should be HCL.
+    config: |
+      ui = true
+
+      listener "tcp" {
+        tls_disable = 1
+        address = "[::]:8200"
+        cluster_address = "[::]:8201"
+      }
+      storage "consul" {
+        path = "vault"
+        address = "HOST_IP:8500"
+      }
+
+      service_registration "kubernetes" {}
+
+      # Example configuration for using auto-unseal, using Google Cloud KMS. The
+      # GKMS keys must already exist, and the cluster must have a service account
+      # that is authorized to access GCP KMS.
+      #seal "gcpckms" {
+      #   project     = "vault-helm-dev-246514"
+      #   region      = "global"
+      #   key_ring    = "vault-helm-unseal-kr"
+      #   crypto_key  = "vault-helm-unseal-key"
+      #}
+
+    # A disruption budget limits the number of pods of a replicated application
+    # that are down simultaneously from voluntary disruptions
+    disruptionBudget:
+      enabled: true
+
+    # maxUnavailable will default to (n/2)-1 where n is the number of
+    # replicas. If you'd like a custom value, you can specify an override here.
+      maxUnavailable: null
+
+  # Definition of the serviceAccount used to run Vault.
+  serviceAccount:
+    # Extra annotations for the serviceAccount definition. This should be a
+    # multi-line string formatted as a map of the annotations to apply to the
+    # serviceAccount.
+    annotations: {}
+
+# Vault UI
+ui:
+  # True if you want to create a Service entry for the Vault UI.
+  #
+  # serviceType can be used to control the type of service created. For
+  # example, setting this to "LoadBalancer" will create an external load
+  # balancer (for supported K8S installations) to access the UI.
+  enabled: false
+  serviceType: "ClusterIP"
+  serviceNodePort: null
+  externalPort: 8200
+
+  # loadBalancerSourceRanges:
+  #   - 10.0.0.0/16
+  #   - 1.78.23.3/32
+
+  # loadBalancerIP:
+
+  # Extra annotations to attach to the ui service
+  # This should be a multi-line string mapping directly to the a map of
+  # the annotations to apply to the ui service
+  annotations: {}

--- a/modules/tools/vault/main.tf
+++ b/modules/tools/vault/main.tf
@@ -1,0 +1,106 @@
+resource "aws_dynamodb_table" "vault_dynamodb_storage" {
+  name           = var.vault_dynamodb_table_name
+  read_capacity  = 5
+  write_capacity = 5
+  hash_key       = "Path"
+  range_key      = "Key"
+  attribute      = [
+    {
+      name = "Path"
+      type = "S"
+    },
+    {
+      name = "Key"
+      type = "S"
+    }
+  ]
+}
+
+resource "aws_kms_key" "vault_seal_key" {
+  description = "KMS key used by Vault for sealing / unsealing"
+}
+
+resource "aws_iam_user" "vault" {
+  name = "vault"
+}
+
+resource "aws_iam_user_policy" "vault" {
+  user   = aws_iam_user.vault.name
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "dynamodb:DescribeLimits",
+        "dynamodb:DescribeTimeToLive",
+        "dynamodb:ListTagsOfResource",
+        "dynamodb:DescribeReservedCapacityOfferings",
+        "dynamodb:DescribeReservedCapacity",
+        "dynamodb:ListTables",
+        "dynamodb:BatchGetItem",
+        "dynamodb:BatchWriteItem",
+        "dynamodb:CreateTable",
+        "dynamodb:DeleteItem",
+        "dynamodb:GetItem",
+        "dynamodb:GetRecords",
+        "dynamodb:PutItem",
+        "dynamodb:Query",
+        "dynamodb:UpdateItem",
+        "dynamodb:Scan",
+        "dynamodb:DescribeTable"
+      ],
+      "Effect": "Allow",
+      "Resource": "${aws_dynamodb_table.vault_dynamodb_storage.arn}"
+    },
+    {
+      "Action": [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:DescribeKey"
+      ],
+      "Effect": "Allow",
+      "Resource": "${aws_kms_key.vault_seal_key.key_id}"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_access_key" "vault" {
+  user = aws_iam_user.vault.name
+}
+
+module "vault_tls_certificate" {
+  source = "../../common/certificates"
+
+  name      = "vault-tls"
+  namespace = var.namespace
+  domain    = "vault.${var.cluster_domain}"
+  enabled   = true
+
+  issuer_name = var.cert_issuer_name
+  issuer_kind = var.cert_issuer_kind
+
+  certificate_crd = var.cert_crd_waiter
+}
+
+resource "helm_release" "vault" {
+  chart     = "${path.module}/charts/vault-helm"
+  name      = "vault"
+  namespace = var.namespace
+  wait      = true
+
+  values = [
+    templatefile("${path.module}/values.tpl", {
+      vault_tls_secret = module.vault_tls_certificate.cert_secret_name
+      vault_config     = indent(6, templatefile("${path.module}/vault-config.hcl.tpl", {
+        region                = var.region
+        aws_access_key_id     = aws_iam_access_key.vault.id
+        aws_secret_access_key = aws_iam_access_key.vault.secret
+        dynamodb_table_name   = aws_dynamodb_table.vault_dynamodb_storage.name
+        kms_key_id            = aws_kms_key.vault_seal_key.key_id
+      }))
+    })
+  ]
+}

--- a/modules/tools/vault/values.tpl
+++ b/modules/tools/vault/values.tpl
@@ -1,0 +1,17 @@
+server:
+  dataStorage:
+    enabled: false # we will use s3 backend for storage, not a local PVC
+  auditStorage:
+    enabled: false # we will use s3 backend for storage, not a local PVC
+  standalone:
+    enabled: false
+  extraVolumes:
+    - type: secret
+      name: ${vault_tls_secret}
+      path: "/tls-certificate"
+  ha:
+    enabled: true
+    config: |
+      ${vault_config}
+ui:
+  enabled: true

--- a/modules/tools/vault/variables.tf
+++ b/modules/tools/vault/variables.tf
@@ -1,0 +1,7 @@
+variable "region" {}
+variable "namespace" {}
+variable "vault_dynamodb_table_name" {}
+variable "cluster_domain" {}
+variable "cert_issuer_name" {}
+variable "cert_issuer_kind" {}
+variable "cert_crd_waiter" {}

--- a/modules/tools/vault/vault-config.hcl.tpl
+++ b/modules/tools/vault/vault-config.hcl.tpl
@@ -1,0 +1,25 @@
+ui = true
+
+listener "tcp" {
+  address                  = "0.0.0.0:8200"
+  tls_cert_file            = "/tls-certificate/tls.crt"
+  tls_key_file             = "/tls-certificate/tls.key"
+  tls_disable_client_certs = true
+}
+
+storage "dynamodb" {
+  region     = "${region}"
+  ha_enabled = "true"
+  table      = "${dynamodb_table_name}"
+
+  access_key = "${aws_access_key_id}"
+  secret_key = "${aws_secret_access_key}"
+}
+
+seal "awskms" {
+  region     = "${region}"
+  access_key = "${aws_access_key_id}"
+  secret_key = "${aws_secret_access_key}"
+
+  kms_key_id = "${kms_key_id}"
+}


### PR DESCRIPTION
don't bother reviewing the contents of `modules/tools/vault/charts/vault-helm`, as that is a direct copy/paste from https://github.com/hashicorp/vault-helm.  it was copy/pasted because this chart is not hosted on a registry

I have not tested this yet on a cluster.