### PR TITLE
initial example vault config

### DIFF
--- a/stacks/apps/sharedsvc/outputs.tf
+++ b/stacks/apps/sharedsvc/outputs.tf
@@ -1,0 +1,3 @@
+output "vault_hostname" {
+  value = local.vault_hostname
+}

--- a/stacks/apps/sharedsvc/vault.tf
+++ b/stacks/apps/sharedsvc/vault.tf
@@ -1,3 +1,7 @@
+locals {
+  vault_hostname = "vault.${var.internal_cluster_domain}"
+}
+
 module "vault_namespace" {
   source      = "../../../modules/common/namespace"
   namespace   = "vault"
@@ -15,6 +19,6 @@ module "vault" {
   cert_issuer_name          = module.internal_services_cluster_issuer.issuer_name
   namespace                 = module.vault_namespace.name
   region                    = var.region
-  vault_hostname            = "vault.internal.services.liatr.io"
-  vault_dynamodb_table_name = "vault.internal.services.liatr.io"
+  vault_hostname            = local.vault_hostname
+  vault_dynamodb_table_name = local.vault_hostname
 }

--- a/stacks/config/sharedsvc/main.tf
+++ b/stacks/config/sharedsvc/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "vault" {
+  address = var.vault_address
+}
+
+resource "vault_mount" "example" {
+  path        = "dummy"
+  type        = "generic"
+  description = "This is an example mount"
+}

--- a/stacks/config/sharedsvc/variables.tf
+++ b/stacks/config/sharedsvc/variables.tf
@@ -1,0 +1,1 @@
+variable "vault_address" {}


### PR DESCRIPTION
this can be applied after running `vault login` and using `terragrunt apply-all` from `lead-environments/aws/liatrio-sharedsvc`