### PR TITLE
Eng 1795 tune prometheus

### DIFF
--- a/modules/common/istio/istio-values.tpl
+++ b/modules/common/istio/istio-values.tpl
@@ -93,12 +93,13 @@ tracing:
   enabled: false
 
 prometheus:
+  retention: 2h
   resources:
     requests:
-      cpu: 300m
-      memory: 3Gi
+      cpu: 500m
+      memory: 5Gi
     limits:
-      cpu: 1.5
+      cpu: 2
       memory: 6Gi
 
 galley:

--- a/modules/common/istio/istio-values.tpl
+++ b/modules/common/istio/istio-values.tpl
@@ -93,7 +93,6 @@ tracing:
   enabled: false
 
 prometheus:
-  retention: 2h
   resources:
     requests:
       cpu: 500m

--- a/modules/lead/toolchain/prometheus-values.tpl
+++ b/modules/lead/toolchain/prometheus-values.tpl
@@ -28,8 +28,8 @@ grafana:
       cpu: 100m
       memory: 128Mi
 
-kubeStateMetrics:
-  deploymentAnnotations:
+kube-state-metrics:
+  podAnnotations:
     downscaler/exclude: "true"
   resources:
     limits:
@@ -38,6 +38,9 @@ kubeStateMetrics:
     requests:
       cpu: 10m
       memory: 32Mi
+  service:
+    annotations:
+      prometheus.io/scrape: "false"
 server:
   deploymentAnnotations:
     downscaler/exclude: "true"
@@ -54,6 +57,9 @@ nodeExporter:
   - key: EssentialOnly
     operator: "Exists"
 prometheus-node-exporter:
+  service:
+    annotations:
+      prometheus.io/scrape: "false"
   resources:
     requests:
       cpu: 10m

--- a/modules/lead/toolchain/prometheus-values.tpl
+++ b/modules/lead/toolchain/prometheus-values.tpl
@@ -92,11 +92,16 @@ prometheus:
               storage: 95Gi
     resources:
       requests:
-        cpu: 250m
-        memory: 2Gi
+        cpu: 500m
+        memory: 3Gi
       limits:
-        cpu: 1500m
+        cpu: 2
         memory: 4Gi
+    containers:
+      - name: prometheus
+        env:
+        - name: GOGC
+          value: "70"
 
 alertmanager:
   enabled: true

--- a/modules/lead/toolchain/prometheus-values.tpl
+++ b/modules/lead/toolchain/prometheus-values.tpl
@@ -33,11 +33,11 @@ kube-state-metrics:
     downscaler/exclude: "true"
   resources:
     limits:
-      cpu: 100m
-      memory: 64Mi
+      cpu: 200m
+      memory: 100Mi
     requests:
       cpu: 10m
-      memory: 32Mi
+      memory: 50Mi
   service:
     annotations:
       prometheus.io/scrape: "false"
@@ -71,10 +71,10 @@ prometheusOperator:
   resources:
     limits:
       cpu: 500m
-      memory: 64Mi
+      memory: 100Mi
     requests:
       cpu: 100m
-      memory: 32Mi
+      memory: 70Mi
   configReloaderCpu: 100m
   configReloaderMemory: 25Mi
   admissionWebhooks:


### PR DESCRIPTION
- remove prometheus scrap annotation (only used by istio promethesu) from kube state metrics and node explorer
- adjust prometheus resources