### PR TITLE
misc fixes related to jaeger tracing

### DIFF
--- a/modules/common/istio/variables.tf
+++ b/modules/common/istio/variables.tf
@@ -20,7 +20,7 @@ variable "ingress_controller_type" {
 }
 
 variable "pilot_trace_sampling" {
-  default = 5.0
+  default = 2.0
 }
 
 variable "flagger_event_webhook" {}

--- a/modules/environment/aws/eks/main.tf
+++ b/modules/environment/aws/eks/main.tf
@@ -179,6 +179,7 @@ module "eks" {
       enabled_metrics        = ["GroupMinSize", "GroupMaxSize", "GroupDesiredCapacity", "GroupInServiceInstances", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
       pre_userdata           = local.ssm_init
       kubelet_extra_args     = "--node-labels=kubernetes.io/lifecycle=essential --register-with-taints=${var.essential_taint_key}=true:NoSchedule"
+      root_volume_size       = var.root_volume_size
     }
   ]
 
@@ -200,6 +201,7 @@ module "eks" {
       kubelet_extra_args                       = "--node-labels=kubernetes.io/lifecycle=preemptible"
       on_demand_base_capacity                  = 0
       on_demand_percentage_above_base_capacity = var.on_demand_percentage
+      root_volume_size                         = var.root_volume_size
     },
     {
       name                                     = "preemptible1"
@@ -218,6 +220,7 @@ module "eks" {
       kubelet_extra_args                       = "--node-labels=kubernetes.io/lifecycle=preemptible"
       on_demand_base_capacity                  = 0
       on_demand_percentage_above_base_capacity = var.on_demand_percentage
+      root_volume_size                         = var.root_volume_size
     },
     {
       name                                     = "preemptible2"
@@ -236,6 +239,7 @@ module "eks" {
       kubelet_extra_args                       = "--node-labels=kubernetes.io/lifecycle=preemptible"
       on_demand_base_capacity                  = 0
       on_demand_percentage_above_base_capacity = var.on_demand_percentage
+      root_volume_size                         = var.root_volume_size
     },
   ]
 }

--- a/modules/environment/aws/eks/variables.tf
+++ b/modules/environment/aws/eks/variables.tf
@@ -66,3 +66,7 @@ variable "cluster_version" {
 }
 
 variable "codebuild_role" {}
+
+variable "root_volume_size" {
+  default = 50
+}

--- a/stacks/environment-aws/elasticsearch.tf
+++ b/stacks/environment-aws/elasticsearch.tf
@@ -14,7 +14,7 @@ module "elasticsearch" {
   cert_manager_crd_waiter = module.cert_manager.crd_waiter
   namespace               = module.elasticsearch_namespace.name
   root_zone_name          = var.root_zone_name
-  disk_size               = "30Gi"
+  disk_size               = "50Gi"
 }
 
 module "kibana" {


### PR DESCRIPTION
- bump elasticsearch disk size
- reduce sampling rate for traces
- decrease EKS worker node root disk size from 100G to 50G