### PR TITLE
Post lab updates

### DIFF
--- a/modules/tools/cluster-autoscaler/cluster-autoscaler-values.tpl
+++ b/modules/tools/cluster-autoscaler/cluster-autoscaler-values.tpl
@@ -17,4 +17,5 @@ autoDiscovery:
 
 extraArgs:
   balance-similar-node-groups: true
+  skip-nodes-with-local-storage: false
   scale-down-enabled: ${scale_down_enabled}

--- a/modules/tools/elasticsearch/elasticsearch-values.tpl
+++ b/modules/tools/elasticsearch/elasticsearch-values.tpl
@@ -10,7 +10,7 @@ volumeClaimTemplate:
 resources:
   requests:
     cpu: 100m
-    memory: 3.5Gi
+    memory: 7.0Gi
   limits:
     cpu: 1000m
     memory: 7.5Gi


### PR DESCRIPTION
- increate es mem request. es will eat up as much memory as it can get it hands on so makes sense to have request closer to limit
- disable skip nodes with local storage. the autoscaler enables this by default which limits how much the cluster can scale down. if we cared about what was being stored by the pod it should have a pvc anyway.