### PR TITLE
Eng 1873

### DIFF
--- a/modules/lead/product-base/database.tf
+++ b/modules/lead/product-base/database.tf
@@ -6,20 +6,9 @@ module "database_namespace" {
     "appmesh.k8s.aws/sidecarInjectorWebhook" = "enabled"
   }
   annotations = {
-    name                                                     = "${var.product_name}-db"
-    "opa.lead.liatrio/ingress-whitelist"                     = "*.${var.product_name}-db.${var.cluster_domain}"
-    "opa.lead.liatrio/image-whitelist"                       = var.image_whitelist
-    "vault.hashicorp.com/agent-inject"                       = "true"
-    "vault.hashicorp.com/role"                               = "${var.product-name}-mongodb"
-    "vault.hashicorp.com/agent-inject-secret-mongodb.json"   = "database/creds/${var.product_name}-mongodb"
-    "vault.hashicorp.com/agent-inject-template-mongodb.json" = <<EOF
-  {{- with secret "database/creds/${var.product_name}-mongodb" -}}
-  {
-    "username": "{{ .Data.username }}",
-    "password": "{{ .Data.password }}"
-  }
-  {{- end }}
-EOF
+    name                                 = "${var.product_name}-db"
+    "opa.lead.liatrio/ingress-whitelist" = "*.${var.product_name}-db.${var.cluster_domain}"
+    "opa.lead.liatrio/image-whitelist"   = var.image_whitelist
   }
 
   providers = {

--- a/modules/lead/product-base/database.tf
+++ b/modules/lead/product-base/database.tf
@@ -22,10 +22,6 @@ data "helm_repository" "bitnami" {
   url  = "https://charts.bitnami.com/bitnami"
 }
 
-data "template_file" "mongo_values" {
-  template = file("${path.module}/mongo.tpl")
-}
-
 resource "helm_release" "mongodb" {
   provider   = helm.system
   name       = "mongodb"
@@ -36,5 +32,12 @@ resource "helm_release" "mongodb" {
   timeout    = 600
   wait       = true
 
-  values = [data.template_file.mongo_values.rendered]
+  values = [
+    templatefile("${path.module}/mongo.tpl", {
+      mongodbRootPassword = random_password.mongodb_root_password.result
+    })
+  ]
+  depends_on = [
+    random_password.mongodb_root_password
+  ]
 }

--- a/modules/lead/product-base/database.tf
+++ b/modules/lead/product-base/database.tf
@@ -37,7 +37,4 @@ resource "helm_release" "mongodb" {
       mongodbRootPassword = random_password.mongodb_root_password.result
     })
   ]
-  depends_on = [
-    random_password.mongodb_root_password
-  ]
 }

--- a/modules/lead/product-base/main.tf
+++ b/modules/lead/product-base/main.tf
@@ -35,3 +35,7 @@ provider "vault" {
   token   = data.kubernetes_secret.vault_root_token_secret.data.token
 }
 
+resource "random_password" "mongodb_root_password" {
+  length = 8
+  special = false
+}

--- a/modules/lead/product-base/main.tf
+++ b/modules/lead/product-base/main.tf
@@ -21,3 +21,17 @@ provider "kubernetes" {
 provider "helm" {
   alias = "system"
 }
+
+data "kubernetes_secret" "vault_root_token_secret" {
+  provider = kubernetes.staging
+  metadata {
+    namespace = "toolchain"
+    name      = "vault-root-token"
+  }
+}
+
+provider "vault" {
+  address = "https://vault.toolchain.${var.cluster_domain}"
+  token   = data.kubernetes_secret.vault_root_token_secret.data.token
+}
+

--- a/modules/lead/product-base/mongo.tpl
+++ b/modules/lead/product-base/mongo.tpl
@@ -1,1 +1,1 @@
-usePassword: false
+mongodbRootPassword: "changeme"

--- a/modules/lead/product-base/mongo.tpl
+++ b/modules/lead/product-base/mongo.tpl
@@ -1,1 +1,1 @@
-mongodbRootPassword: "changeme"
+mongodbRootPassword: "${mongodbRootPassword}"

--- a/modules/lead/product-base/staging.tf
+++ b/modules/lead/product-base/staging.tf
@@ -162,7 +162,7 @@ resource "vault_database_secret_backend_role" "mongodb_role" {
       roles = [
         {
           role = "readWrite"
-          db   = "database"
+          db   = "staging"
         }
       ]
     })

--- a/modules/lead/product-base/staging.tf
+++ b/modules/lead/product-base/staging.tf
@@ -142,7 +142,7 @@ resource "vault_database_secret_backend_connection" "mongodb" {
 
   data = {
     username = "root"
-    password = "changeme"
+    password = random_password.mongodb_root_password.result
   }
 
   mongodb {
@@ -189,7 +189,7 @@ resource "vault_kubernetes_auth_backend_role" "vault_auth_role" {
   bound_service_account_names = [
     "*"
   ]
-  bound_service_account_namespaces = [ // Can scope this to just <product>-staging at end
+  bound_service_account_namespaces = [
     "${var.product_name}-staging"
   ]
 

--- a/modules/lead/product-base/staging.tf
+++ b/modules/lead/product-base/staging.tf
@@ -171,8 +171,8 @@ resource "vault_database_secret_backend_role" "mongodb_role" {
   db_name = vault_database_secret_backend_connection.mongodb.name
   name    = local.vault_mongodb_role
 
-  default_ttl = 60
-  max_ttl     = 60
+  default_ttl = 600
+  max_ttl     = 600
 }
 
 resource "vault_policy" "get_mongodb_creds" {

--- a/modules/lead/product-base/staging.tf
+++ b/modules/lead/product-base/staging.tf
@@ -178,7 +178,7 @@ resource "vault_database_secret_backend_role" "mongodb_role" {
 resource "vault_policy" "get_mongodb_creds" {
   name   = "get-${var.product_name}-mongodb-creds"
   policy = <<EOF
-path "mongodb/creds/${var.product_name}-staging/" {
+path "mongodb/creds/${var.product_name}-staging" {
   capabilities = ["read"]
 }
 EOF

--- a/modules/tools/vault-less-secure/main.tf
+++ b/modules/tools/vault-less-secure/main.tf
@@ -168,34 +168,7 @@ resource "vault_auth_backend" "kubernetes" {
 
 resource "vault_kubernetes_auth_backend_config" "k8s_vault_backend_config" {
   backend            = vault_auth_backend.kubernetes.path
-  kubernetes_host    = var.cluster_domain
-  kubernetes_ca_cert = data.kubernetes_secret.vault_token_reviewer_service_account_token.data["ca.crt"] // should be "default" svc acct cert
-  token_reviewer_jwt = data.kubernetes_secret.vault_token_reviewer_service_account_token.data["token"]  //should be "default" svc acct token
-}
-
-resource "vault_policy" "token_lookup_self" {
-  name   = "token-lookup-self"
-  policy = <<EOF
-path "auth/token/lookup-self" {
-  capabilities = ["read", "update"]
-}
-EOF
-}
-
-resource "vault_kubernetes_auth_backend_role" "vault_auth_role" {
-  backend = vault_auth_backend.kubernetes.path
-  bound_service_account_names = [
-    kubernetes_service_account.vault_token_reviewer.metadata[0].name
-  ]
-  bound_service_account_namespaces = [
-    "*"
-  ]
-  role_name = "vault_auth_role"
-
-  token_ttl     = 300
-  token_max_ttl = 300
-  token_policies = [
-    vault_policy.token_lookup_self.name,
-    "default"
-  ]
+  kubernetes_host    = "https://kubernetes.default.svc"
+  kubernetes_ca_cert = data.kubernetes_secret.vault_token_reviewer_service_account_token.data["ca.crt"]
+  token_reviewer_jwt = data.kubernetes_secret.vault_token_reviewer_service_account_token.data["token"]
 }

--- a/modules/tools/vault-less-secure/variables.tf
+++ b/modules/tools/vault-less-secure/variables.tf
@@ -2,3 +2,4 @@ variable "region" {}
 variable "namespace" {}
 variable "vault_dynamodb_table_name" {}
 variable "vault_hostname" {}
+variable "cluster_domain" {}

--- a/modules/tools/vault-less-secure/vault-injector-values.tpl
+++ b/modules/tools/vault-less-secure/vault-injector-values.tpl
@@ -1,0 +1,2 @@
+injector:
+  externalVaultAddr: "${vault_hostname}"

--- a/modules/tools/vault-less-secure/vault-values.tpl
+++ b/modules/tools/vault-less-secure/vault-values.tpl
@@ -1,6 +1,9 @@
 global:
   tlsDisable: true
 
+injector:
+  enabled: false
+
 server:
   image:
     tag: ${vault_version}

--- a/stacks/environment-aws/lead.tf
+++ b/stacks/environment-aws/lead.tf
@@ -145,6 +145,9 @@ module "lab_partner" {
 module "vault" {
   source = "../../modules/tools/vault-less-secure"
 
+  providers = {
+    vault = vault.vault_less_secure
+  }
   namespace                 = module.toolchain.namespace
   region                    = var.region
   vault_dynamodb_table_name = "vault.toolchain.${module.eks.cluster_id}.${var.root_zone_name}"

--- a/stacks/environment-aws/lead.tf
+++ b/stacks/environment-aws/lead.tf
@@ -92,7 +92,7 @@ module "sdm" {
   harbor_image_repo = "harbor.${module.toolchain.namespace}.${module.eks.cluster_id}.${var.root_zone_name}"
   ecr_image_repo    = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${var.region}.amazonaws.com"
 
-  operator_slack_service_account_annotations   = {
+  operator_slack_service_account_annotations = {
     "eks.amazonaws.com/role-arn" = aws_iam_role.operator_slack_service_account.arn
   }
   operator_jenkins_service_account_annotations = {
@@ -123,10 +123,10 @@ module "sdm" {
 }
 
 module "dashboard" {
-  source                           = "../../modules/lead/dashboard"
-  enabled                          = var.enable_dashboard
-  namespace                        = module.toolchain.namespace
-  dashboard_version                = var.dashboard_version
+  source            = "../../modules/lead/dashboard"
+  enabled           = var.enable_dashboard
+  namespace         = module.toolchain.namespace
+  dashboard_version = var.dashboard_version
 }
 
 module "lab_partner" {
@@ -149,4 +149,5 @@ module "vault" {
   region                    = var.region
   vault_dynamodb_table_name = "vault.toolchain.${module.eks.cluster_id}.${var.root_zone_name}"
   vault_hostname            = "vault.toolchain.${module.eks.cluster_id}.${var.root_zone_name}"
+  cluster_domain            = "${var.cluster}.${var.root_zone_name}"
 }

--- a/stacks/environment-aws/main.tf
+++ b/stacks/environment-aws/main.tf
@@ -51,3 +51,17 @@ provider "vault" {
     }
   }
 }
+
+data "kubernetes_secret" "vault_root_token_secret" {
+  metadata {
+    namespace = module.vault.vault_namespace
+    name      = module.vault.vault_root_token_secret
+  }
+}
+
+provider "vault" {
+  address = "https://vault.toolchain.${module.eks.cluster_id}.${var.root_zone_name}"
+  token   = data.kubernetes_secret.vault_root_token_secret.data.token
+
+  alias = "vault_less_secure"
+}


### PR DESCRIPTION
This PR will enable the Product Operator to configure a role, policy, and backend connection for each instance of a Product that is stood up. Applications that wish to use these credentials will need to define Pod annotations to allow a vault-agent side car to be injected that will it's Product's roles/policies to obtain new credentials for it's MongoDB instance.