### PR TITLE
Relocated kube-resource-report module to tools/

### DIFF
--- a/modules/lead/toolchain/kube-resource-report.tf
+++ b/modules/lead/toolchain/kube-resource-report.tf
@@ -1,7 +1,0 @@
-module "kube_resource_report" {
-  source = "../../tools/kube-resource-report"
-
-  cluster        = var.cluster
-  namespace      = var.namespace
-  root_zone_name = var.root_zone_name
-}

--- a/stacks/environment-aws/lead.tf
+++ b/stacks/environment-aws/lead.tf
@@ -149,3 +149,11 @@ module "prometheus-operator" {
   prometheus_slack_webhook_url = data.vault_generic_secret.prometheus.data["slack-webhook-url"]
   prometheus_slack_channel     = var.prometheus_slack_channel
 }
+
+module "kube_resource_report" {
+  source = "../../modules/tools/kube-resource-report"
+
+  namespace      = module.toolchain.namespace
+  cluster        = var.cluster
+  root_zone_name = var.root_zone_name
+}

--- a/stacks/environment-local/lead.tf
+++ b/stacks/environment-local/lead.tf
@@ -109,3 +109,11 @@ module "prometheus-operator" {
   prometheus_slack_webhook_url = var.prometheus_slack_webhook_url
   prometheus_slack_channel     = var.prometheus_slack_channel
 }
+
+module "kube_resource_report" {
+  source = "../../modules/tools/kube-resource-report"
+
+  namespace      = module.toolchain.namespace
+  cluster        = var.cluster
+  root_zone_name = var.root_zone_name
+}


### PR DESCRIPTION
This PR relocates the existing `kube-resource-report` module from the `toolchain` module to its own module under `module/tools`. Corresponding updates have been made to both the `local` and `environment-aws` stacks. 