### PR TITLE
Updated harbor and keycloak provider config to point to Terraform registry

### DIFF
--- a/modules/lead/toolchain/harbor.tf
+++ b/modules/lead/toolchain/harbor.tf
@@ -3,11 +3,6 @@ locals {
   notary_hostname = "notary.${module.toolchain_namespace.name}.${var.cluster}.${var.root_zone_name}"
 }
 
-resource "random_string" "harbor_admin_password" {
-  length = 10
-  special = false
-}
-
 resource "random_string" "harbor_db_password" {
   length = 10
   special = false
@@ -134,7 +129,7 @@ resource "helm_release" "harbor" {
 
   set_sensitive {
     name = "harborAdminPassword"
-    value = random_string.harbor_admin_password.result
+    value = var.harbor_admin_password
   }
 
   set_sensitive {
@@ -210,7 +205,7 @@ resource "helm_release" "harbor_config" {
 
   set_sensitive {
     name = "harbor.password"
-    value = random_string.harbor_admin_password.result
+    value = var.harbor_admin_password
   }
 
   set {
@@ -227,12 +222,6 @@ resource "helm_release" "harbor_config" {
     name = "keycloak.secret"
     value = keycloak_openid_client.harbor_client[0].client_secret
   }
-}
-
-provider "harbor" {
-  url      = "https://${local.harbor_hostname}"
-  username = "admin"
-  password = random_string.harbor_admin_password.result
 }
 
 resource "harbor_project" "liatrio_project" {

--- a/modules/lead/toolchain/keycloak.tf
+++ b/modules/lead/toolchain/keycloak.tf
@@ -44,19 +44,6 @@ resource "helm_release" "keycloak" {
   }
 }
 
-
-# while using client credentials is preferred, it would require initial client creation using the
-# old realm import method, so just use password based setup since that is known prior to keycloak
-# resource
-provider "keycloak" {
-  client_id      = "admin-cli"
-  username       = "keycloak"
-  password       = var.keycloak_admin_password
-  url            = "${local.protocol}://${local.keycloak_hostname}"
-  initial_login  = false
-  client_timeout = 15
-}
-
 # Give Keycloak API a chance to become responsive
 resource "null_resource" "keycloak_realm_delay" {
   count      = var.enable_keycloak ? 1 : 0

--- a/modules/lead/toolchain/outputs.tf
+++ b/modules/lead/toolchain/outputs.tf
@@ -1,6 +1,5 @@
 output "namespace" {
   value = module.toolchain_namespace.name
-  depends_on = [kubernetes_cluster_role_binding.tiller_cluster_role_binding]
 }
 
 output "keycloak_domain" {

--- a/modules/lead/toolchain/variables.tf
+++ b/modules/lead/toolchain/variables.tf
@@ -45,6 +45,9 @@ variable "enable_harbor" {
   default = true
 }
 
+variable "harbor_admin_password" {
+}
+
 variable "enable_rode" {
   default = true
 }

--- a/modules/lead/toolchain/versions.tf
+++ b/modules/lead/toolchain/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 0.13"
   required_providers {
@@ -6,35 +5,15 @@ terraform {
       source = "hashicorp/external"
     }
     harbor = {
-      source = "terraform.local/liatrio/harbor"
-      # TF-UPGRADE-TODO
-      #
-      # No source detected for this provider. You must add a source address
-      # in the following format:
-      #
-      # source = "your-registry.example.com/organization/harbor"
-      #
-      # For more information, see the provider source documentation:
-      #
-      # https://www.terraform.io/docs/configuration/providers.html#provider-source
-      version = "= 0.1.0"
+      source = "liatrio/harbor"
+      version = "= 0.2.0-pre"
     }
     helm = {
       source = "hashicorp/helm"
     }
     keycloak = {
-      source = "terraform.local/liatrio/keycloak"
-      # TF-UPGRADE-TODO
-      #
-      # No source detected for this provider. You must add a source address
-      # in the following format:
-      #
-      # source = "your-registry.example.com/organization/keycloak"
-      #
-      # For more information, see the provider source documentation:
-      #
-      # https://www.terraform.io/docs/configuration/providers.html#provider-source
-      version = "= 1.18.0"
+      source = "mrparkers/keycloak"
+      version = "= 2.0.0-rc.0"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"

--- a/modules/lead/toolchain/versions.tf
+++ b/modules/lead/toolchain/versions.tf
@@ -1,4 +1,52 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    external = {
+      source = "hashicorp/external"
+    }
+    harbor = {
+      source = "terraform.local/liatrio/harbor"
+      # TF-UPGRADE-TODO
+      #
+      # No source detected for this provider. You must add a source address
+      # in the following format:
+      #
+      # source = "your-registry.example.com/organization/harbor"
+      #
+      # For more information, see the provider source documentation:
+      #
+      # https://www.terraform.io/docs/configuration/providers.html#provider-source
+      version = "= 0.1.0"
+    }
+    helm = {
+      source = "hashicorp/helm"
+    }
+    keycloak = {
+      source = "terraform.local/liatrio/keycloak"
+      # TF-UPGRADE-TODO
+      #
+      # No source detected for this provider. You must add a source address
+      # in the following format:
+      #
+      # source = "your-registry.example.com/organization/keycloak"
+      #
+      # For more information, see the provider source documentation:
+      #
+      # https://www.terraform.io/docs/configuration/providers.html#provider-source
+      version = "= 1.18.0"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    null = {
+      source = "hashicorp/null"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
 }

--- a/modules/tools/kibana/versions.tf
+++ b/modules/tools/kibana/versions.tf
@@ -4,35 +4,11 @@ terraform {
     external = {
       source = "hashicorp/external"
     }
-    harbor = {
-      source = "liatrio/harbor"
-      # TF-UPGRADE-TODO
-      #
-      # No source detected for this provider. You must add a source address
-      # in the following format:
-      #
-      # source = "your-registry.example.com/organization/harbor"
-      #
-      # For more information, see the provider source documentation:
-      #
-      # https://www.terraform.io/docs/configuration/providers.html#provider-source
-      version = "= 0.2.0-pre"
-    }
     helm = {
       source = "hashicorp/helm"
     }
     keycloak = {
       source = "mrparkers/keycloak"
-      # TF-UPGRADE-TODO
-      #
-      # No source detected for this provider. You must add a source address
-      # in the following format:
-      #
-      # source = "your-registry.example.com/organization/keycloak"
-      #
-      # For more information, see the provider source documentation:
-      #
-      # https://www.terraform.io/docs/configuration/providers.html#provider-source
       version = "= 2.0.0-rc.0"
     }
     kubernetes = {

--- a/modules/tools/kibana/versions.tf
+++ b/modules/tools/kibana/versions.tf
@@ -1,6 +1,5 @@
-
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
   required_providers {
     external = {
       source = "hashicorp/external"

--- a/stacks/environment-aws/lead.tf
+++ b/stacks/environment-aws/lead.tf
@@ -33,6 +33,7 @@ module "toolchain" {
   google_identity_provider_client_secret = var.enable_google_login ? data.vault_generic_secret.keycloak.data["google-idp-client-secret"] : ""
   enable_test_user                       = var.enable_test_user
   test_user_password                     = var.enable_test_user ? data.vault_generic_secret.keycloak.data["test-user-password"] : ""
+  harbor_admin_password                  = random_string.harbor_admin_password.result
   enable_istio                           = var.enable_istio
   enable_artifactory                     = var.enable_artifactory
   enable_gitlab                          = var.enable_gitlab

--- a/stacks/environment-aws/lead.tf
+++ b/stacks/environment-aws/lead.tf
@@ -10,6 +10,10 @@ data "vault_generic_secret" "keycloak" {
   path = "lead/aws/${data.aws_caller_identity.current.account_id}/keycloak"
 }
 
+data "vault_generic_secret" "harbor" {
+  path = "lead/aws/${data.aws_caller_identity.current.account_id}/harbor"
+}
+
 data "vault_generic_secret" "prometheus" {
   path = "lead/aws/${data.aws_caller_identity.current.account_id}/prometheus"
 }
@@ -33,7 +37,7 @@ module "toolchain" {
   google_identity_provider_client_secret = var.enable_google_login ? data.vault_generic_secret.keycloak.data["google-idp-client-secret"] : ""
   enable_test_user                       = var.enable_test_user
   test_user_password                     = var.enable_test_user ? data.vault_generic_secret.keycloak.data["test-user-password"] : ""
-  harbor_admin_password                  = random_string.harbor_admin_password.result
+  harbor_admin_password                  = data.vault_generic_secret.keycloak.data["admin-password"]
   enable_istio                           = var.enable_istio
   enable_artifactory                     = var.enable_artifactory
   enable_gitlab                          = var.enable_gitlab

--- a/stacks/environment-aws/lead.tf
+++ b/stacks/environment-aws/lead.tf
@@ -37,7 +37,7 @@ module "toolchain" {
   google_identity_provider_client_secret = var.enable_google_login ? data.vault_generic_secret.keycloak.data["google-idp-client-secret"] : ""
   enable_test_user                       = var.enable_test_user
   test_user_password                     = var.enable_test_user ? data.vault_generic_secret.keycloak.data["test-user-password"] : ""
-  harbor_admin_password                  = data.vault_generic_secret.keycloak.data["admin-password"]
+  harbor_admin_password                  = data.vault_generic_secret.harbor.data["admin-password"]
   enable_istio                           = var.enable_istio
   enable_artifactory                     = var.enable_artifactory
   enable_gitlab                          = var.enable_gitlab

--- a/stacks/environment-aws/main.tf
+++ b/stacks/environment-aws/main.tf
@@ -61,14 +61,9 @@ provider "keycloak" {
   client_timeout = 15
 }
 
-resource "random_string" "harbor_admin_password" {
-  length = 10
-  special = false
-}
-
 provider "harbor" {
   url      = "harbor.${var.toolchain_namespace}.${var.cluster}.${var.root_zone_name}"
   username = "admin"
-  password = random_string.harbor_admin_password.result
+  password = data.vault_generic_secret.harbor.data["admin-password"]
 }
 

--- a/stacks/environment-aws/main.tf
+++ b/stacks/environment-aws/main.tf
@@ -51,3 +51,24 @@ provider "vault" {
     }
   }
 }
+
+provider "keycloak" {
+  client_id      = "admin-cli"
+  username       = "keycloak"
+  password       = data.vault_generic_secret.keycloak.data["admin-password"]
+  url            = var.root_zone_name == "localhost" ? "http://${var.cluster}.${var.root_zone_name}" : "https://${var.cluster}.${var.root_zone_name}"
+  initial_login  = false
+  client_timeout = 15
+}
+
+resource "random_string" "harbor_admin_password" {
+  length = 10
+  special = false
+}
+
+provider "harbor" {
+  url      = "harbor.${var.toolchain_namespace}.${var.cluster}.${var.root_zone_name}"
+  username = "admin"
+  password = random_string.harbor_admin_password.result
+}
+

--- a/stacks/environment-aws/versions.tf
+++ b/stacks/environment-aws/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 0.12"
   required_providers {
@@ -7,16 +6,6 @@ terraform {
     }
     harbor = {
       source = "liatrio/harbor"
-      # TF-UPGRADE-TODO
-      #
-      # No source detected for this provider. You must add a source address
-      # in the following format:
-      #
-      # source = "your-registry.example.com/organization/harbor"
-      #
-      # For more information, see the provider source documentation:
-      #
-      # https://www.terraform.io/docs/configuration/providers.html#provider-source
       version = "= 0.2.0-pre"
     }
     helm = {
@@ -24,16 +13,6 @@ terraform {
     }
     keycloak = {
       source = "mrparkers/keycloak"
-      # TF-UPGRADE-TODO
-      #
-      # No source detected for this provider. You must add a source address
-      # in the following format:
-      #
-      # source = "your-registry.example.com/organization/keycloak"
-      #
-      # For more information, see the provider source documentation:
-      #
-      # https://www.terraform.io/docs/configuration/providers.html#provider-source
       version = "= 2.0.0-rc.0"
     }
     kubernetes = {

--- a/stacks/environment-aws/versions.tf
+++ b/stacks/environment-aws/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
   required_providers {
     external = {
       source = "hashicorp/external"


### PR DESCRIPTION
This PR updates the required_providers config to point to the newly published `harbor` and `keycloak` providers.