### PR TITLE
Use updated k8s secret name for keycloak

### DIFF
--- a/modules/lead/product-jenkins/keycloak.tf
+++ b/modules/lead/product-jenkins/keycloak.tf
@@ -1,9 +1,9 @@
 
-data "kubernetes_secret" "keycloak_admin_credential" {
+data "kubernetes_secret" "keycloak-credentials" {
   provider = kubernetes.toolchain
 
   metadata {
-    name      = "keycloak-admin-credential"
+    name      = "keycloak-credentials"
     namespace = "toolchain"
   }
 }
@@ -20,8 +20,8 @@ data "kubernetes_secret" "keycloak_toolchain_realm" {
 provider "keycloak" {
   client_id = "admin-cli"
   // trick provider into not caring if username/password don't exist
-  username      = var.enable_keycloak ? data.kubernetes_secret.keycloak_admin_credential.data.username : "username"
-  password      = var.enable_keycloak ? data.kubernetes_secret.keycloak_admin_credential.data.password : "password"
+  username      = var.enable_keycloak ? data.kubernetes_secret.keycloak-credentials.data.admin_username : "username"
+  password      = var.enable_keycloak ? data.kubernetes_secret.keycloak-credentials.data.admin_password : "password"
   url           = "${local.protocol}://keycloak.toolchain.${var.cluster_domain}"
   initial_login = false
 }

--- a/modules/lead/product-jenkins/keycloak.tf
+++ b/modules/lead/product-jenkins/keycloak.tf
@@ -1,5 +1,5 @@
 
-data "kubernetes_secret" "keycloak-credentials" {
+data "kubernetes_secret" "keycloak_credentials" {
   provider = kubernetes.toolchain
 
   metadata {
@@ -20,8 +20,8 @@ data "kubernetes_secret" "keycloak_toolchain_realm" {
 provider "keycloak" {
   client_id = "admin-cli"
   // trick provider into not caring if username/password don't exist
-  username      = var.enable_keycloak ? data.kubernetes_secret.keycloak-credentials.data.admin_username : "username"
-  password      = var.enable_keycloak ? data.kubernetes_secret.keycloak-credentials.data.admin_password : "password"
+  username      = var.enable_keycloak ? data.kubernetes_secret.keycloak_credentials.data.admin_username : "username"
+  password      = var.enable_keycloak ? data.kubernetes_secret.keycloak_credentials.data.admin_password : "password"
   url           = "${local.protocol}://keycloak.toolchain.${var.cluster_domain}"
   initial_login = false
 }


### PR DESCRIPTION
As part of https://github.com/liatrio/lead-terraform/commit/7c85d0e3909bd82d394d47d4f0b2b507830d3838#diff-5180734303cdbe1d5e9ffd88b33501c4 we renamed the metadata for the keycloak_admin kubernetes secret to "keycloak_credentials" and updated the metadata. Updating the product-jenkins keylcloak module to use the appropriate secret name and values. 