### PR TITLE
increase success threshold for mongodb liveness and readiness probes

### DIFF
--- a/modules/lead/product-base/mongo.tpl
+++ b/modules/lead/product-base/mongo.tpl
@@ -2,7 +2,5 @@ auth:
   rootPassword: "${mongodbRootPassword}"
 useStatefulSet: true
 
-livenessProbe:
-  successThreshold: 2
 readinessProbe:
   successThreshold: 2

--- a/modules/lead/product-base/mongo.tpl
+++ b/modules/lead/product-base/mongo.tpl
@@ -1,3 +1,8 @@
 auth:
   rootPassword: "${mongodbRootPassword}"
 useStatefulSet: true
+
+livenessProbe:
+  successThreshold: 2
+readinessProbe:
+  successThreshold: 2


### PR DESCRIPTION
without this change, there's a small chance that the mongodb pod is not actually ready for authentication attempts by the time that the helm chart finishes deploying, causing an issue with the terraform code that sets up a connection between vault and mongodb.