### PR TITLE
remove maven secret volume

### DIFF
--- a/modules/lead/product-jenkins/pod-templates.tpl
+++ b/modules/lead/product-jenkins/pod-templates.tpl
@@ -174,9 +174,6 @@ jenkins:
                 resourceLimitMemory: 1024Mi
             slaveConnectTimeout: 100
             volumes:
-              - secretVolume:
-                  mountPath: "/root/.m2"
-                  secretName: "jenkins-artifactory-maven-settings"
               - emptyDirVolume:
                   mountPath: "/root/.m2/repository"
                   memory: false
@@ -211,9 +208,6 @@ jenkins:
                 resourceLimitMemory: 1024Mi
             slaveConnectTimeout: 100
             volumes:
-              - secretVolume:
-                  mountPath: "/root/.m2"
-                  secretName: "jenkins-artifactory-maven-settings"
               - emptyDirVolume:
                   mountPath: "/root/.m2/repository"
                   memory: false


### PR DESCRIPTION
accidentally left this in when I copy and pasted the the maven template but that secret doesn't exist after artifactory was removed so the maven template was probably broken also.