### PR TITLE
prevent vault root token change

### DIFF
--- a/modules/tools/vault-less-secure/main.tf
+++ b/modules/tools/vault-less-secure/main.tf
@@ -39,4 +39,8 @@ resource "kubernetes_secret" "vault_root_token" {
   data = {
     token = module.vault_operator_init.stdout
   }
+
+  lifecycle {
+    ignore_changes = [data]
+  }
 }


### PR DESCRIPTION
this should prevent cases where the vault root token stored in a k8s secret is replaced with an empty string because the shell script resource is recreated, tries to unlock vault again and returns an error. 