### PR TITLE
Terraform 14 upgrade

### DIFF
--- a/modules/lead/product-jenkins/versions.tf
+++ b/modules/lead/product-jenkins/versions.tf
@@ -10,16 +10,8 @@ terraform {
       source = "hashicorp/helm"
     }
     keycloak = {
-      # TF-UPGRADE-TODO
-      #
-      # No source detected for this provider. You must add a source address
-      # in the following format:
-      #
-      # source = "your-registry.example.com/organization/keycloak"
-      #
-      # For more information, see the provider source documentation:
-      #
-      # https://www.terraform.io/docs/configuration/providers.html#provider-source
+      source = "mrparkers/keycloak"
+      version = "= 2.0.0-rc.0"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"

--- a/modules/lead/product-jenkins/versions.tf
+++ b/modules/lead/product-jenkins/versions.tf
@@ -1,10 +1,34 @@
 
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 0.13"
   required_providers {
     harbor = {
-      source = "liatrio/harbor"
+      source  = "liatrio/harbor"
       version = "= 0.3.3"
+    }
+    helm = {
+      source = "hashicorp/helm"
+    }
+    keycloak = {
+      # TF-UPGRADE-TODO
+      #
+      # No source detected for this provider. You must add a source address
+      # in the following format:
+      #
+      # source = "your-registry.example.com/organization/keycloak"
+      #
+      # For more information, see the provider source documentation:
+      #
+      # https://www.terraform.io/docs/configuration/providers.html#provider-source
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    template = {
+      source = "hashicorp/template"
     }
   }
 }

--- a/modules/lead/product-jenkins/versions.tf
+++ b/modules/lead/product-jenkins/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     keycloak = {
       source = "mrparkers/keycloak"
-      version = "= 2.0.0-rc.0"
+      version = "= 2.3.0"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"

--- a/stacks/product-jenkins/versions.tf
+++ b/stacks/product-jenkins/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/stacks/product-jenkins/versions.tf
+++ b/stacks/product-jenkins/versions.tf
@@ -18,7 +18,7 @@ terraform {
 
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "= 2.0.0-rc.0"
+      version = "= 2.3.0"
     }
 
     template = {

--- a/stacks/product-jenkins/versions.tf
+++ b/stacks/product-jenkins/versions.tf
@@ -10,5 +10,19 @@ terraform {
       source  = "hashicorp/helm"
       version = "2.0.2"
     }
+
+    harbor = {
+      source  = "liatrio/harbor"
+      version = "= 0.3.3"
+    }
+
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 2.0.0-rc.0"
+    }
+
+    template = {
+      source  = "hashicorp/template"
+    }
   }
 }

--- a/stages/cloud-provider/aws/lead/iam.tf
+++ b/stages/cloud-provider/aws/lead/iam.tf
@@ -270,7 +270,8 @@ resource "aws_iam_policy" "product_operator_main" {
       "s3:DeleteObject"
     ],
     "Resource": [
-      "arn:aws:s3:::lead-sdm-operators-${data.aws_caller_identity.current.account_id}-${var.cluster_name}.liatr.io"
+      "arn:aws:s3:::lead-sdm-operators-${data.aws_caller_identity.current.account_id}-${var.cluster_name}.liatr.io",
+      "arn:aws:s3:::lead-sdm-operators-${data.aws_caller_identity.current.account_id}-${var.cluster_name}.liatr.io/*"
     ]
   },
   {


### PR DESCRIPTION
Updated the version of Terraform that product-jenkins was using from 12 to 13 and then to 14, expanded the IAM role permissions for the S3 bucket to compensate for the update. Listed the providers in required_providers section inside the versions.tf file as required by the Terraform 13 update.