### PR TITLE
Revert "remove k8s provider in cloud-provider tf stage"

### DIFF
--- a/stages/cloud-provider/aws/lead/main.tf
+++ b/stages/cloud-provider/aws/lead/main.tf
@@ -7,4 +7,18 @@ provider "aws" {
   region  = var.region
 }
 
+data "aws_eks_cluster" "cluster" {
+  name = module.eks.cluster_id
+}
+
 data "aws_caller_identity" "current" {}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
+  exec {
+    api_version = "client.authentication.k8s.io/v1alpha1"
+    args        = ["eks", "get-token", "--cluster-name", var.cluster_name]
+    command     = "aws"
+  }
+}


### PR DESCRIPTION
Reverts liatrio/lead-terraform#436

turns out this is actually needed within the `eks` module.  my bad