### PR TITLE
deploy ingress controllers for app traffic

### DIFF
--- a/modules/lead/app-ingress/README.md
+++ b/modules/lead/app-ingress/README.md
@@ -1,0 +1,5 @@
+This module can be used in place of Istio to provide connectivity to deployed applications in the cluster.
+
+This will deploy two additional instances of "ingress-nginx", and configure them to use different ingress classes for staging and production.
+
+This module should only be used when istio is disabled.

--- a/modules/lead/app-ingress/main.tf
+++ b/modules/lead/app-ingress/main.tf
@@ -1,0 +1,39 @@
+module "staging_app_wildcard" {
+  source = "../../common/certificates"
+
+  name      = "staging-app-wildcard"
+  namespace = var.namespace
+  domain    = "staging.apps.${var.cluster_domain}"
+
+  issuer_name = var.issuer_name
+  issuer_kind = var.issuer_kind
+}
+
+module "prod_app_wildcard" {
+  source = "../../common/certificates"
+
+  name      = "prod-app-wildcard"
+  namespace = var.namespace
+  domain    = "prod.apps.${var.cluster_domain}"
+
+  issuer_name = var.issuer_name
+  issuer_kind = var.issuer_kind
+}
+
+module "staging_app_nginx" {
+  source = "../../tools/nginx"
+
+  name                = "staging-app"
+  ingress_class       = "staging-app-nginx"
+  namespace           = var.namespace
+  default_certificate = "${var.namespace}/${module.staging_app_wildcard.cert_secret_name}"
+}
+
+module "prod_app_nginx" {
+  source = "../../tools/nginx"
+
+  name                = "prod-app"
+  ingress_class       = "prod-app-nginx"
+  namespace           = var.namespace
+  default_certificate = "${var.namespace}/${module.prod_app_wildcard.cert_secret_name}"
+}

--- a/modules/lead/app-ingress/variables.tf
+++ b/modules/lead/app-ingress/variables.tf
@@ -1,0 +1,4 @@
+variable "namespace" {}
+variable "cluster_domain" {}
+variable "issuer_name" {}
+variable "issuer_kind" {}

--- a/stages/apps/lead/nginx.tf
+++ b/stages/apps/lead/nginx.tf
@@ -1,0 +1,10 @@
+# create an ingress controller for handling application traffic if istio is not installed
+module "app_nginx" {
+  count  = var.enable_istio ? 0 : 1
+  source = "../../../modules/lead/app-ingress"
+
+  cluster_domain = "${var.cluster_name}.${var.root_zone_name}"
+  issuer_name    = module.cluster_issuer.issuer_name
+  issuer_kind    = module.cluster_issuer.issuer_kind
+  namespace      = module.toolchain_namespace.name
+}


### PR DESCRIPTION
if istio is disabled, this will allow applications to still be exposed via `Ingress` instead of using a `VirtualService` / `Gateway`