### PR TITLE
upgrade cert manager chart version to 1.2.0

### DIFF
--- a/modules/tools/cert-manager/main.tf
+++ b/modules/tools/cert-manager/main.tf
@@ -4,7 +4,7 @@ resource "helm_release" "cert_manager" {
   chart      = "cert-manager"
   repository = "https://charts.jetstack.io"
   timeout    = 120
-  version    = "v0.16.1"
+  version    = "v1.2.0"
   wait       = true
 
   set {


### PR DESCRIPTION
this change was already made but must of gotten lost when we updated the k8s version