### PR TITLE
avoid downscaling internal ingress

### DIFF
--- a/modules/common/nginx-ingress/main.tf
+++ b/modules/common/nginx-ingress/main.tf
@@ -15,6 +15,7 @@ resource "helm_release" "nginx_ingress" {
       service_account                     = var.service_account
       service_annotations                 = var.service_annotations
       service_load_balancer_source_ranges = var.service_load_balancer_source_ranges
+      deployment_annotations              = var.deployment_annotations
       cluster_wide                        = var.cluster_wide
       default_certificate                 = var.default_certificate
     })

--- a/modules/common/nginx-ingress/nginx-ingress-values.tpl
+++ b/modules/common/nginx-ingress/nginx-ingress-values.tpl
@@ -24,10 +24,14 @@ controller:
   service:
     type: ${ingress_controller_type}
     externalTrafficPolicy: ${ingress_external_traffic_policy}
+    %{ if length(service_annotations) != 0 }
     annotations:
-      ${indent( 6, yamlencode( service_annotations ) ) }
+      ${indent(6, yamlencode(service_annotations))}
+    %{ endif }
+    %{ if length(service_load_balancer_source_ranges) != 0 }
     loadBalancerSourceRanges:
-      ${indent( 6, yamlencode( service_load_balancer_source_ranges ) ) }
+      ${indent(6, yamlencode(service_load_balancer_source_ranges))}
+    %{ endif }
   resources:
     requests:
       cpu: 300m
@@ -35,6 +39,10 @@ controller:
     limits:
       cpu: 750m
       memory: 512Mi
+  %{ if length(deployment_annotations) != 0 }
+  deploymentAnnotations:
+    ${indent(4, yamlencode(deployment_annotations))}
+  %{ endif }
 defaultBackend:
   resources:
     requests:

--- a/modules/common/nginx-ingress/variables.tf
+++ b/modules/common/nginx-ingress/variables.tf
@@ -26,3 +26,7 @@ variable "service_load_balancer_source_ranges" {
   type    = list(string)
   default = []
 }
+
+variable "deployment_annotations" {
+  default = []
+}

--- a/modules/lead/toolchain-ingress/main.tf
+++ b/modules/lead/toolchain-ingress/main.tf
@@ -215,6 +215,9 @@ module "internal_ingress" {
   service_annotations = {
     "service.beta.kubernetes.io/aws-load-balancer-internal": true
   }
+  deployment_annotations = {
+    "downscaler/downtime-replicas": "1"
+  }
   service_load_balancer_source_ranges = var.internal_ingress_source_ranges
   service_account                     = kubernetes_service_account.internal_nginx_ingress_service_account.metadata[0].name
   cluster_wide                        = true


### PR DESCRIPTION
I ended up using the `downscaler/downtime-replicas` annotation so we'd just have one replica for the controller running off-hours.