### PR TITLE
bump CPU limits for docker registry pods

### DIFF
--- a/modules/tools/docker-registry/values.yaml.tpl
+++ b/modules/tools/docker-registry/values.yaml.tpl
@@ -43,5 +43,5 @@ resources:
     cpu: 100m
     memory: 128Mi
   limits:
-    cpu: 200m
+    cpu: 500m
     memory: 256Mi


### PR DESCRIPTION
I saw a lot of throttling when testing this with a few different images