### PR TITLE
Adding sonarqube to shared services

### DIFF
--- a/modules/environment/aws/eks/main.tf
+++ b/modules/environment/aws/eks/main.tf
@@ -9,7 +9,7 @@ systemctl enable amazon-ssm-agent
 
 echo '{"registry-mirrors": [${ var.docker_registry_mirror != "" ? format("\"%s\"", var.docker_registry_mirror) : ""}]}' | cat /etc/docker/daemon.json - | jq -s '.[0] * .[1]' > /tmp/daemon.json
 mv /tmp/daemon.json /etc/docker/daemon.json
-systemctl reload docker
+systemctl restart docker
 EOF
 
   tags = {

--- a/modules/environment/aws/eks/main.tf
+++ b/modules/environment/aws/eks/main.tf
@@ -9,7 +9,7 @@ systemctl enable amazon-ssm-agent
 
 echo '{"registry-mirrors": [${ var.docker_registry_mirror != "" ? format("\"%s\"", var.docker_registry_mirror) : ""}]}' | cat /etc/docker/daemon.json - | jq -s '.[0] * .[1]' > /tmp/daemon.json
 mv /tmp/daemon.json /etc/docker/daemon.json
-systemctl restart docker
+systemctl reload docker
 EOF
 
   tags = {

--- a/modules/environment/aws/iam/external-dns/main.tf
+++ b/modules/environment/aws/iam/external-dns/main.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "external_dns_service_account" {
-  name = "${var.cluster}_external_dns_service_account"
+  name = "${var.cluster}-${var.service_account_name}-service-account"
 
   assume_role_policy = <<EOF
 {
@@ -13,7 +13,7 @@ resource "aws_iam_role" "external_dns_service_account" {
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringEquals": {
-          "${replace(var.openid_connect_provider_url, "https://", "")}:sub": "system:serviceaccount:${var.namespace}:external-dns"
+          "${replace(var.openid_connect_provider_url, "https://", "")}:sub": "system:serviceaccount:${var.namespace}:${var.service_account_name}"
         }
       }
     }
@@ -23,7 +23,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "external_dns" {
-  name = "${var.cluster}-external-dns"
+  name = "${var.cluster}-${var.service_account_name}"
   role = aws_iam_role.external_dns_service_account.name
 
   policy = <<EOF

--- a/modules/environment/aws/iam/external-dns/variables.tf
+++ b/modules/environment/aws/iam/external-dns/variables.tf
@@ -5,3 +5,7 @@ variable "openid_connect_provider_url" {}
 variable "route53_zone_ids" {
   type = list(string)
 }
+
+variable "service_account_name" {
+  default = "external-dns"
+}

--- a/modules/tools/external-dns/main.tf
+++ b/modules/tools/external-dns/main.tf
@@ -38,7 +38,7 @@ resource "helm_release" "external_dns" {
 resource "kubernetes_service_account" "external_dns_service_account" {
   count                           = var.enabled ? 1 : 0
   metadata {
-    name        = "external-dns"
+    name        = var.release_name
     namespace   = var.namespace
     annotations = var.service_account_annotations
   }
@@ -48,7 +48,7 @@ resource "kubernetes_service_account" "external_dns_service_account" {
 resource "kubernetes_cluster_role" "external_dns_role" {
   count = var.enabled ? 1 : 0
   metadata {
-    name = "external-dns-manager"
+    name = "${var.release_name}-manager"
   }
   rule {
     api_groups = [
@@ -99,7 +99,7 @@ resource "kubernetes_cluster_role" "external_dns_role" {
 resource "kubernetes_cluster_role_binding" "external_dns_role_binding" {
   count = var.enabled ? 1 : 0
   metadata {
-    name = "external-dns-binding"
+    name = "${var.release_name}-binding"
   }
   role_ref {
     api_group = "rbac.authorization.k8s.io"

--- a/modules/tools/external-dns/main.tf
+++ b/modules/tools/external-dns/main.tf
@@ -2,27 +2,28 @@ resource "helm_release" "external_dns" {
   count      = var.enabled ? 1 : 0
   repository = "https://charts.bitnami.com/bitnami"
   chart      = "external-dns"
-  version    = "2.21.1"
+  version    = "5.2.3"
   namespace  = var.namespace
   name       = var.release_name
   timeout    = 600
 
   values = [
     templatefile("${path.module}/values.tpl", {
-      aws_zone_type  = var.aws_zone_type
-      dns_provider   = var.dns_provider
-      domain_filters = yamlencode(var.domain_filters)
-      istio_enabled  = var.istio_enabled
-      watch_services = var.watch_services
+      aws_zone_type   = var.aws_zone_type
+      dns_provider    = var.dns_provider
+      domain_filters  = yamlencode(var.domain_filters)
+      istio_enabled   = var.istio_enabled
+      watch_services  = var.watch_services
+      exclude_domains = var.exclude_domains
     })
   ]
 
   set {
-    name  = "rbac.serviceAccountName"
+    name  = "serviceAccount.name"
     value = kubernetes_service_account.external_dns_service_account[0].metadata[0].name
   }
   set {
-    name  = "rbac.serviceAccountCreate"
+    name  = "serviceAccount.create"
     value = "false"
   }
   set {

--- a/modules/tools/external-dns/main.tf
+++ b/modules/tools/external-dns/main.tf
@@ -4,7 +4,7 @@ resource "helm_release" "external_dns" {
   chart      = "external-dns"
   version    = "2.21.1"
   namespace  = var.namespace
-  name       = "external-dns"
+  name       = var.release_name
   timeout    = 600
 
   values = [

--- a/modules/tools/external-dns/values.tpl
+++ b/modules/tools/external-dns/values.tpl
@@ -9,6 +9,12 @@ sources:
 %{~ endif }
 domainFilters:
 ${domain_filters}
+%{~ if length(exclude_domains) > 0 ~}
+excludeDomains:
+%{ for domain in exclude_domains ~}
+- ${domain}
+%{~ endfor }
+%{~ endif ~}
 %{~ if dns_provider == "aws" }
 aws:
   zoneType: ${aws_zone_type}

--- a/modules/tools/external-dns/variables.tf
+++ b/modules/tools/external-dns/variables.tf
@@ -34,3 +34,7 @@ variable "namespace" {
 variable "aws_zone_type" {
   default = "public"
 }
+
+variable "release_name" {
+  default = "external-dns"
+}

--- a/modules/tools/external-dns/variables.tf
+++ b/modules/tools/external-dns/variables.tf
@@ -38,3 +38,8 @@ variable "aws_zone_type" {
 variable "release_name" {
   default = "external-dns"
 }
+
+variable "exclude_domains" {
+  type = list(string)
+  default = []
+}

--- a/stages/apps/sharedsvc/infrastructure.tf
+++ b/stages/apps/sharedsvc/infrastructure.tf
@@ -42,6 +42,24 @@ module "external_dns" {
   watch_services              = true
 }
 
+module "external_dns_public" {
+  source = "../../../modules/tools/external-dns"
+
+  enabled                     = true
+  release_name                = "external-dns-public"
+  istio_enabled               = false
+  dns_provider                = "aws"
+  service_account_annotations = {
+    "eks.amazonaws.com/role-arn" = var.external_dns_service_account_arn
+  }
+  domain_filters              = [
+    var.cluster_domain
+  ]
+  namespace                   = module.system_namespace.name
+  aws_zone_type               = "public"
+  watch_services              = true
+}
+
 module "cert_manager" {
   source                                = "../../../modules/tools/cert-manager"
   namespace                             = module.system_namespace.name
@@ -66,7 +84,7 @@ module "aws_node_termination_handler" {
 module "kube_janitor" {
   source = "../../../modules/tools/kube-janitor"
 
-  namespace    = module.system_namespace.name
+  namespace = module.system_namespace.name
 }
 
 module "essential_toleration_values" {

--- a/stages/apps/sharedsvc/infrastructure.tf
+++ b/stages/apps/sharedsvc/infrastructure.tf
@@ -34,7 +34,6 @@ module "external_dns" {
     "eks.amazonaws.com/role-arn" = var.external_dns_service_account_arn
   }
   domain_filters              = [
-    var.cluster_domain,
     var.internal_cluster_domain
   ]
   namespace                   = module.system_namespace.name
@@ -50,7 +49,7 @@ module "external_dns_public" {
   istio_enabled               = false
   dns_provider                = "aws"
   service_account_annotations = {
-    "eks.amazonaws.com/role-arn" = var.external_dns_service_account_arn
+    "eks.amazonaws.com/role-arn" = var.external_dns_public_service_account_arn
   }
   domain_filters              = [
     var.cluster_domain
@@ -58,6 +57,7 @@ module "external_dns_public" {
   namespace                   = module.system_namespace.name
   aws_zone_type               = "public"
   watch_services              = true
+  exclude_domains             = [var.internal_cluster_domain]
 }
 
 module "cert_manager" {

--- a/stages/apps/sharedsvc/issuers.tf
+++ b/stages/apps/sharedsvc/issuers.tf
@@ -2,6 +2,10 @@ data "aws_route53_zone" "public_internal_services_liatr_io" {
   name         = "${var.internal_cluster_domain}."
 }
 
+data "aws_route53_zone" "public_services_liatr_io" {
+  name         = "${var.cluster_domain}."
+}
+
 module "internal_services_cluster_issuer" {
   source        = "../../../modules/common/cert-issuer"
   namespace     = module.system_namespace.name
@@ -15,6 +19,25 @@ module "internal_services_cluster_issuer" {
 
   route53_dns_region      = var.region
   route53_dns_hosted_zone = data.aws_route53_zone.public_internal_services_liatr_io.zone_id
+
+  depends_on = [
+    module.cert_manager
+  ]
+}
+
+module "internal_services_cluster_issuer_external" {
+  source        = "../../../modules/common/cert-issuer"
+  namespace     = module.system_namespace.name
+  issuer_name   = "letsencrypt-dns"
+  issuer_kind   = "ClusterIssuer"
+  issuer_type   = "acme"
+  issuer_server = "https://acme-v02.api.letsencrypt.org/directory"
+
+  acme_solver       = "dns"
+  provider_dns_type = "route53"
+
+  route53_dns_region      = var.region
+  route53_dns_hosted_zone = data.aws_route53_zone.public_services_liatr_io.zone_id
 
   depends_on = [
     module.cert_manager

--- a/stages/apps/sharedsvc/issuers.tf
+++ b/stages/apps/sharedsvc/issuers.tf
@@ -25,10 +25,10 @@ module "internal_services_cluster_issuer" {
   ]
 }
 
-module "internal_services_cluster_issuer_external" {
+module "external_services_cluster_issuer" {
   source        = "../../../modules/common/cert-issuer"
   namespace     = module.system_namespace.name
-  issuer_name   = "letsencrypt-dns"
+  issuer_name   = "letsencrypt-dns-external"
   issuer_kind   = "ClusterIssuer"
   issuer_type   = "acme"
   issuer_server = "https://acme-v02.api.letsencrypt.org/directory"

--- a/stages/apps/sharedsvc/main.tf
+++ b/stages/apps/sharedsvc/main.tf
@@ -32,3 +32,19 @@ provider "helm" {
     }
   }
 }
+
+provider "vault" {
+  address = var.vault_address
+
+  auth_login {
+    path = "auth/aws/login"
+
+    parameters = {
+      role                    = "aws-admin"
+      iam_http_request_method = "POST"
+      iam_request_url         = base64encode("https://sts.amazonaws.com/")
+      iam_request_body        = base64encode("Action=GetCallerIdentity&Version=2011-06-15")
+      iam_request_headers     = var.iam_caller_identity_headers
+    }
+  }
+}

--- a/stages/apps/sharedsvc/main.tf
+++ b/stages/apps/sharedsvc/main.tf
@@ -11,6 +11,8 @@ data "aws_eks_cluster" "cluster" {
   name = var.eks_cluster_id
 }
 
+data "aws_caller_identity" "current" {}
+
 provider "kubernetes" {
   host                   = data.aws_eks_cluster.cluster.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)

--- a/stages/apps/sharedsvc/nginx.tf
+++ b/stages/apps/sharedsvc/nginx.tf
@@ -41,7 +41,7 @@ module "nginx" {
 
 module "nginx_external" {
   source              = "../../../modules/tools/nginx"
-  default_certificate = "${module.nginx_ingress_namespace.name}/${module.wildcard.cert_secret_name}"
+  default_certificate = "${module.nginx_ingress_namespace.name}/${module.wildcard_external.cert_secret_name}"
   internal            = false
   namespace           = module.nginx_ingress_namespace.name
   ingress_class       = "nginx-external"

--- a/stages/apps/sharedsvc/nginx.tf
+++ b/stages/apps/sharedsvc/nginx.tf
@@ -19,9 +19,29 @@ module "wildcard" {
   issuer_kind = module.internal_services_cluster_issuer.issuer_kind
 }
 
+module "wildcard_external" {
+  source = "../../../modules/common/certificates"
+
+  name      = "external-services-wildcard"
+  namespace = module.nginx_ingress_namespace.name
+  domain    = var.cluster_domain
+  enabled   = true
+
+  issuer_name = module.internal_services_cluster_issuer_external.issuer_name
+  issuer_kind = module.internal_services_cluster_issuer_external.issuer_kind
+}
+
 module "nginx" {
   source              = "../../../modules/tools/nginx"
   default_certificate = "${module.nginx_ingress_namespace.name}/${module.wildcard.cert_secret_name}"
   internal            = true
   namespace           = module.nginx_ingress_namespace.name
+}
+
+module "nginx_external" {
+  source              = "../../../modules/tools/nginx"
+  default_certificate = "${module.nginx_ingress_namespace.name}/${module.wildcard.cert_secret_name}"
+  internal            = false
+  namespace           = module.nginx_ingress_namespace.name
+  ingress_class       = "nginx-external"
 }

--- a/stages/apps/sharedsvc/nginx.tf
+++ b/stages/apps/sharedsvc/nginx.tf
@@ -27,8 +27,8 @@ module "wildcard_external" {
   domain    = var.cluster_domain
   enabled   = true
 
-  issuer_name = module.internal_services_cluster_issuer_external.issuer_name
-  issuer_kind = module.internal_services_cluster_issuer_external.issuer_kind
+  issuer_name = module.external_services_cluster_issuer.issuer_name
+  issuer_kind = module.external_services_cluster_issuer.issuer_kind
 }
 
 module "nginx" {
@@ -36,6 +36,7 @@ module "nginx" {
   default_certificate = "${module.nginx_ingress_namespace.name}/${module.wildcard.cert_secret_name}"
   internal            = true
   namespace           = module.nginx_ingress_namespace.name
+  name                = "internal"
 }
 
 module "nginx_external" {
@@ -44,4 +45,5 @@ module "nginx_external" {
   internal            = false
   namespace           = module.nginx_ingress_namespace.name
   ingress_class       = "nginx-external"
+  name                = "external"
 }

--- a/stages/apps/sharedsvc/sonarqube.tf
+++ b/stages/apps/sharedsvc/sonarqube.tf
@@ -1,0 +1,22 @@
+data "vault_generic_secret" "sonarqube" {
+  path = "lead/aws/${data.aws_caller_identity.current.account_id}/sonarqube"
+}
+
+module "sonarqube_namespace" {
+  source      = "../../../modules/common/namespace"
+  namespace   = "sonarqube"
+}
+
+module "sonarqube" {
+  source = "../../../modules/tools/sonarqube"
+
+  admin_password    = data.vault_generic_secret.sonarqube.data["admin_password"]
+  postgres_password = data.vault_generic_secret.sonarqube.data["postgres_password"]
+  namespace         = module.sonarqube_namespace.name
+  ingress_enabled   = true
+  ingress_hostname  = "sonarqube.${var.cluster_domain}"
+  ingress_annotations = {
+    "kubernetes.io/ingress.class" : "nginx-external"
+  }
+}
+

--- a/stages/apps/sharedsvc/sonarqube.tf
+++ b/stages/apps/sharedsvc/sonarqube.tf
@@ -1,5 +1,3 @@
-data "aws_caller_identity" "current" {}
-
 data "vault_generic_secret" "sonarqube" {
   path = "lead/aws/${data.aws_caller_identity.current.account_id}/sonarqube"
 }

--- a/stages/apps/sharedsvc/sonarqube.tf
+++ b/stages/apps/sharedsvc/sonarqube.tf
@@ -1,5 +1,5 @@
 data "vault_generic_secret" "sonarqube" {
-  path = "lead/aws/${data.aws_caller_identity.current.account_id}/sonarqube"
+  path = "lead/aws/265560927720/sonarqube"
 }
 
 module "sonarqube_namespace" {
@@ -10,8 +10,8 @@ module "sonarqube_namespace" {
 module "sonarqube" {
   source = "../../../modules/tools/sonarqube"
 
-  admin_password    = data.vault_generic_secret.sonarqube.data["admin_password"]
-  postgres_password = data.vault_generic_secret.sonarqube.data["postgres_password"]
+  admin_password    = data.vault_generic_secret.sonarqube.data["admin"]
+  postgres_password = data.vault_generic_secret.sonarqube.data["postgres"]
   namespace         = module.sonarqube_namespace.name
   ingress_enabled   = true
   ingress_hostname  = "sonarqube.${var.cluster_domain}"

--- a/stages/apps/sharedsvc/sonarqube.tf
+++ b/stages/apps/sharedsvc/sonarqube.tf
@@ -1,5 +1,7 @@
+data "aws_caller_identity" "current" {}
+
 data "vault_generic_secret" "sonarqube" {
-  path = "lead/aws/265560927720/sonarqube"
+  path = "lead/aws/${data.aws_caller_identity.current.account_id}/sonarqube"
 }
 
 module "sonarqube_namespace" {

--- a/stages/apps/sharedsvc/variables.tf
+++ b/stages/apps/sharedsvc/variables.tf
@@ -48,3 +48,7 @@ variable "docker_registry_s3_bucket_name" {}
 variable "dashboard_version" {
   default = "v2.0.1-11-g444016b"
 }
+
+variable "vault_address" {}
+
+variable "iam_caller_identity_headers" {}

--- a/stages/apps/sharedsvc/variables.tf
+++ b/stages/apps/sharedsvc/variables.tf
@@ -49,6 +49,8 @@ variable "dashboard_version" {
   default = "v2.0.1-11-g444016b"
 }
 
-variable "vault_address" {}
+variable "vault_address" {
+  default = "https://vault.internal.services.liatr.io"
+}
 
 variable "iam_caller_identity_headers" {}

--- a/stages/apps/sharedsvc/variables.tf
+++ b/stages/apps/sharedsvc/variables.tf
@@ -39,6 +39,7 @@ variable "vault_kms_key_id" {
 
 variable "cluster_autoscaler_service_account_arn" {}
 variable "external_dns_service_account_arn" {}
+variable "external_dns_public_service_account_arn" {}
 variable "cert_manager_service_account_arn" {}
 
 variable "docker_registry_aws_access_key_id" {}

--- a/stages/cloud-provider/aws/sharedsvc/iam.tf
+++ b/stages/cloud-provider/aws/sharedsvc/iam.tf
@@ -29,8 +29,20 @@ module "external_dns_iam" {
   openid_connect_provider_url = module.eks.aws_iam_openid_connect_provider.url
   route53_zone_ids            = [
     data.aws_route53_zone.private_internal_services_liatr_io.zone_id,
+  ]
+}
+
+module "external_dns_iam_public" {
+  source = "../../../../modules/environment/aws/iam/external-dns"
+
+  cluster                     = module.eks.cluster_id
+  namespace                   = var.system_namespace
+  openid_connect_provider_arn = module.eks.aws_iam_openid_connect_provider.arn
+  openid_connect_provider_url = module.eks.aws_iam_openid_connect_provider.url
+  route53_zone_ids            = [
     data.aws_route53_zone.services_liatr_io.zone_id
   ]
+  service_account_name        = "external-dns-public"
 }
 
 module "cert_manager_iam" {

--- a/stages/cloud-provider/aws/sharedsvc/outputs.tf
+++ b/stages/cloud-provider/aws/sharedsvc/outputs.tf
@@ -37,6 +37,11 @@ output "cluster_autoscaler_service_account_arn" {
 output "external_dns_service_account_arn" {
   value = module.external_dns_iam.external_dns_service_account_arn
 }
+
+output "external_dns_public_service_account_arn" {
+  value = module.external_dns_iam_public.external_dns_service_account_arn
+}
+
 output "cert_manager_service_account_arn" {
   value = module.cert_manager_iam.cert_manager_service_account_arn
 }

--- a/stages/config/sharedsvc/vault.tf
+++ b/stages/config/sharedsvc/vault.tf
@@ -47,6 +47,7 @@ resource "vault_aws_auth_backend_role" "aws_admin" {
     local.sandbox_aws_account,
     local.remote_k8s_aws_account,
     local.rtx_aws_account,
+    local.sharedsvc_aws_account,
   ])
   resolve_aws_unique_ids   = false
   token_policies           = [
@@ -64,6 +65,7 @@ resource "vault_aws_auth_backend_role" "aws_developer" {
     local.sandbox_aws_account,
     local.remote_k8s_aws_account,
     local.rtx_aws_account,
+    local.sharedsvc_aws_account,
   ])
   resolve_aws_unique_ids   = false
   token_policies           = [


### PR DESCRIPTION
* Adds sonarqube deployment to shared services cluster
* Handles some errors from the latest AMI version used by the cluster
* Adds an additional external-dns release to handle the public zone
* Adds external-facing ingress components
* Upgrades the external-dns release to the latest version