### PR TITLE
chore: upgrade jenkins chart, fix issues with cloning large repositories

### DIFF
--- a/modules/lead/product-jenkins/controller.tpl
+++ b/modules/lead/product-jenkins/controller.tpl
@@ -1,3 +1,6 @@
 jenkins:
   labelString: "controller"
   numExecutors: 1
+unclassified:
+  location:
+    url: ${root_url}

--- a/modules/lead/product-jenkins/controller.tpl
+++ b/modules/lead/product-jenkins/controller.tpl
@@ -1,6 +1,8 @@
 jenkins:
   labelString: "controller"
-  numExecutors: 1
+  numExecutors: 0
+  remotingSecurity:
+    enabled: true
 unclassified:
   location:
     url: ${root_url}

--- a/modules/lead/product-jenkins/controller.tpl
+++ b/modules/lead/product-jenkins/controller.tpl
@@ -1,0 +1,3 @@
+jenkins:
+  labelString: "controller"
+  numExecutors: 1

--- a/modules/lead/product-jenkins/github.tf
+++ b/modules/lead/product-jenkins/github.tf
@@ -22,7 +22,7 @@ resource "kubernetes_secret" "github" {
     labels = {
       "app.kubernetes.io/name"       = "jenkins"
       "app.kubernetes.io/instance"   = "jenkins"
-      "app.kubernetes.io/component"  = "jenkins-master"
+      "app.kubernetes.io/component"  = "jenkins-controller"
       "app.kubernetes.io/managed-by" = "Terraform"
       "jenkins.io/credentials-type"  = "usernamePassword"
     }
@@ -48,7 +48,7 @@ resource "kubernetes_secret" "github_token" {
     labels = {
       "app.kubernetes.io/name"       = "jenkins"
       "app.kubernetes.io/instance"   = "jenkins"
-      "app.kubernetes.io/component"  = "jenkins-master"
+      "app.kubernetes.io/component"  = "jenkins-controller"
       "app.kubernetes.io/managed-by" = "Terraform"
       "jenkins.io/credentials-type"  = "secretText"
     }
@@ -73,7 +73,7 @@ resource "kubernetes_config_map" "jcasc_github_plugin" {
     labels = {
       "app.kubernetes.io/name"       = "jenkins"
       "app.kubernetes.io/instance"   = "jenkins"
-      "app.kubernetes.io/component"  = "jenkins-master"
+      "app.kubernetes.io/component"  = "jenkins-controller"
       "app.kubernetes.io/managed-by" = "Terraform"
       "jenkins-jenkins-config"       = "true"
     }

--- a/modules/lead/product-jenkins/jenkins-env.tpl
+++ b/modules/lead/product-jenkins/jenkins-env.tpl
@@ -18,5 +18,3 @@ jenkins:
           value: "staging.${appDomain}"
         - key: "productionDomain"
           value: "prod.${appDomain}"
-        - key: "JAVA_OPTS"
-          value: "-Djenkins.install.runSetupWizard=false"

--- a/modules/lead/product-jenkins/jenkins-env.tpl
+++ b/modules/lead/product-jenkins/jenkins-env.tpl
@@ -18,3 +18,5 @@ jenkins:
           value: "staging.${appDomain}"
         - key: "productionDomain"
           value: "prod.${appDomain}"
+        - key: "JAVA_OPTS"
+          value: "-Djenkins.install.runSetupWizard=false"

--- a/modules/lead/product-jenkins/jenkins-values.tpl
+++ b/modules/lead/product-jenkins/jenkins-values.tpl
@@ -52,12 +52,12 @@ controller:
       welcome-message: |
         jenkins:
           systemMessage: Welcome to our CI\CD server.  This Jenkins is configured and managed 'as code' from https://github.com/liatrio/lead-terraform.
-    authorizationStrategy: |-
-      loggedInUsersCanDoAnything:
-        allowAnonymousRead: ${!enable_keycloak}
-    %{~ if enable_keycloak }
-    securityRealm: keycloak
-    %{~ endif }
+      authorizationStrategy: |
+        loggedInUsersCanDoAnything:
+          allowAnonymousRead: ${!enable_keycloak}
+      %{~ if enable_keycloak }
+      securityRealm: keycloak
+      %{~ endif }
 
   sidecars:
     configAutoReload:

--- a/modules/lead/product-jenkins/jenkins-values.tpl
+++ b/modules/lead/product-jenkins/jenkins-values.tpl
@@ -52,14 +52,12 @@ controller:
       welcome-message: |
         jenkins:
           systemMessage: Welcome to our CI\CD server.  This Jenkins is configured and managed 'as code' from https://github.com/liatrio/lead-terraform.
-      authorizationStrategy:
-        loggedInUsersCanDoAnything:
-          %{~ if enable_keycloak }
-          allowAnonymousRead: "false"
-        securityRealm: keycloak
-          %{~ else }
-          allowAnonymousRead: "true"
-          %{~ endif }
+    authorizationStrategy: |-
+      loggedInUsersCanDoAnything:
+        allowAnonymousRead: ${!enable_keycloak}
+    %{~ if enable_keycloak }
+    securityRealm: keycloak
+    %{~ endif }
 
   sidecars:
     configAutoReload:

--- a/modules/lead/product-jenkins/jenkins-values.tpl
+++ b/modules/lead/product-jenkins/jenkins-values.tpl
@@ -6,8 +6,8 @@ persistence:
   enabled: true
 
 controller:
-  image: harbor.parker.gg/library/jenkins-updated-plugins
-  tag: v7
+  image: "${toolchain_image_repo}/jenkins-image"
+  tag: ${jenkins_image_version}
 
   installPlugins: false
 

--- a/modules/lead/product-jenkins/jenkins-values.tpl
+++ b/modules/lead/product-jenkins/jenkins-values.tpl
@@ -6,8 +6,8 @@ persistence:
   enabled: true
 
 controller:
-  image: "${toolchain_image_repo}/jenkins-image"
-  tag: ${jenkins_image_version}
+  image: harbor.parker.gg/library/jenkins-updated-plugins
+  tag: v7
 
   installPlugins: false
 

--- a/modules/lead/product-jenkins/jenkins-values.tpl
+++ b/modules/lead/product-jenkins/jenkins-values.tpl
@@ -6,8 +6,8 @@ persistence:
   enabled: true
 
 controller:
-  image: "${toolchain_image_repo}/jenkins-image"
-  tag: ${jenkins_image_version}
+  image: harbor.parker.gg/library/jenkins-updated-plugins
+  tag: v2
 
   installPlugins: false
 

--- a/modules/lead/product-jenkins/jenkins-values.tpl
+++ b/modules/lead/product-jenkins/jenkins-values.tpl
@@ -52,6 +52,14 @@ controller:
       welcome-message: |
         jenkins:
           systemMessage: Welcome to our CI\CD server.  This Jenkins is configured and managed 'as code' from https://github.com/liatrio/lead-terraform.
+      authorizationStrategy:
+        loggedInUsersCanDoAnything:
+          %{~ if enable_keycloak }
+          allowAnonymousRead: "false"
+        securityRealm: keycloak
+          %{~ else }
+          allowAnonymousRead: "true"
+          %{~ endif }
 
   sidecars:
     configAutoReload:

--- a/modules/lead/product-jenkins/jenkins-values.tpl
+++ b/modules/lead/product-jenkins/jenkins-values.tpl
@@ -7,7 +7,7 @@ persistence:
 
 controller:
   image: harbor.parker.gg/library/jenkins-updated-plugins
-  tag: v2
+  tag: v3
 
   installPlugins: false
 

--- a/modules/lead/product-jenkins/jenkins-values.tpl
+++ b/modules/lead/product-jenkins/jenkins-values.tpl
@@ -3,12 +3,16 @@ serviceAccount:
   name: ${service_account_name}
 
 persistence:
-  enabled: false
+  enabled: true
 
-master:
-  installPlugins: false
+controller:
   image: "${toolchain_image_repo}/jenkins-image"
   tag: ${jenkins_image_version}
+
+  installPlugins: false
+
+  serviceType: ClusterIP
+  jenkinsUrlProtocol: ${protocol}
   ingress:
     enabled: true
     hostName: ${ingress_hostname}
@@ -24,12 +28,15 @@ master:
     tls:
     - hosts:
       - ${ingress_hostname}
-  jenkinsUrlProtocol: ${protocol}
-  serviceType: ClusterIP
-  healthProbeLivenessFailureThreshold: 5
-  healthProbeReadinessFailureThreshold: 12
-  healthProbeLivenessInitialDelay: 60
-  healthProbeReadinessInitialDelay: 30
+
+  probes:
+    livenessProbe:
+      failureThreshold: 5
+      initialDelaySeconds: 60
+    readinessProbe:
+      failureThreshold: 12
+      initialDelaySeconds: 30
+
   resources:
     requests:
       cpu: 250m
@@ -39,9 +46,8 @@ master:
       memory: 2Gi
 
   JCasC:
+    defaultConfig: false
     enabled: true
-    pluginVersion: 1.19
-    supportPluginVersion: 1.19
     configScripts:
       welcome-message: |
         jenkins:
@@ -50,7 +56,6 @@ master:
   sidecars:
     configAutoReload:
       enabled: true
-      label: jenkins_config
       resources:
         requests:
           cpu: 100m

--- a/modules/lead/product-jenkins/jenkins-values.tpl
+++ b/modules/lead/product-jenkins/jenkins-values.tpl
@@ -7,7 +7,7 @@ persistence:
 
 controller:
   image: harbor.parker.gg/library/jenkins-updated-plugins
-  tag: v4
+  tag: v6
 
   installPlugins: false
 

--- a/modules/lead/product-jenkins/jenkins-values.tpl
+++ b/modules/lead/product-jenkins/jenkins-values.tpl
@@ -7,8 +7,8 @@ persistence:
 
 master:
   installPlugins: false
-  image: "${toolchain_image_repo}/jenkins-image"
-  tag: ${jenkins_image_version}
+  image: harbor.parker.gg/library/jenkins-updated-plugins
+  tag: v2
   ingress:
     enabled: true
     hostName: ${ingress_hostname}

--- a/modules/lead/product-jenkins/jenkins-values.tpl
+++ b/modules/lead/product-jenkins/jenkins-values.tpl
@@ -1,14 +1,14 @@
 serviceAccount:
   create: false
-  name: jenkins
+  name: ${service_account_name}
 
 persistence:
   enabled: false
 
 master:
   installPlugins: false
-  image: harbor.parker.gg/library/jenkins-updated-plugins
-  tag: v2
+  image: "${toolchain_image_repo}/jenkins-image"
+  tag: ${jenkins_image_version}
   ingress:
     enabled: true
     hostName: ${ingress_hostname}

--- a/modules/lead/product-jenkins/jenkins-values.tpl
+++ b/modules/lead/product-jenkins/jenkins-values.tpl
@@ -7,7 +7,7 @@ persistence:
 
 controller:
   image: harbor.parker.gg/library/jenkins-updated-plugins
-  tag: v3
+  tag: v4
 
   installPlugins: false
 

--- a/modules/lead/product-jenkins/jenkins-values.tpl
+++ b/modules/lead/product-jenkins/jenkins-values.tpl
@@ -50,6 +50,8 @@ master:
   containerEnv:
     - name: elasticUrl
       value: http://lead-dashboard-logstash.toolchain.svc.cluster.local:9000
+    - name: JAVA_OPTS
+      value: "-Djenkins.install.runSetupWizard=false"
 
   sidecars:
     configAutoReload:

--- a/modules/lead/product-jenkins/jenkins-values.tpl
+++ b/modules/lead/product-jenkins/jenkins-values.tpl
@@ -52,12 +52,6 @@ controller:
       welcome-message: |
         jenkins:
           systemMessage: Welcome to our CI\CD server.  This Jenkins is configured and managed 'as code' from https://github.com/liatrio/lead-terraform.
-      authorizationStrategy: |
-        loggedInUsersCanDoAnything:
-          allowAnonymousRead: ${!enable_keycloak}
-      %{~ if enable_keycloak }
-      securityRealm: keycloak
-      %{~ endif }
 
   sidecars:
     configAutoReload:

--- a/modules/lead/product-jenkins/jenkins-values.tpl
+++ b/modules/lead/product-jenkins/jenkins-values.tpl
@@ -47,12 +47,6 @@ master:
         jenkins:
           systemMessage: Welcome to our CI\CD server.  This Jenkins is configured and managed 'as code' from https://github.com/liatrio/lead-terraform.
 
-  containerEnv:
-    - name: elasticUrl
-      value: http://lead-dashboard-logstash.toolchain.svc.cluster.local:9000
-    - name: JAVA_OPTS
-      value: "-Djenkins.install.runSetupWizard=false"
-
   sidecars:
     configAutoReload:
       enabled: true

--- a/modules/lead/product-jenkins/jenkins-values.tpl
+++ b/modules/lead/product-jenkins/jenkins-values.tpl
@@ -7,7 +7,7 @@ persistence:
 
 controller:
   image: harbor.parker.gg/library/jenkins-updated-plugins
-  tag: v6
+  tag: v7
 
   installPlugins: false
 

--- a/modules/lead/product-jenkins/main.tf
+++ b/modules/lead/product-jenkins/main.tf
@@ -1,5 +1,6 @@
 locals {
   protocol = var.cluster_domain == "docker-for-desktop.localhost" ? "http" : "https"
+  ingress_hostname = "${module.toolchain_namespace.name}.jenkins.${var.cluster_domain}"
 }
 
 provider "kubernetes" {

--- a/modules/lead/product-jenkins/master-node.tpl
+++ b/modules/lead/product-jenkins/master-node.tpl
@@ -1,3 +1,0 @@
-jenkins:
-  labelString: "master"
-  numExecutors: 1

--- a/modules/lead/product-jenkins/pipelines-git.tpl
+++ b/modules/lead/product-jenkins/pipelines-git.tpl
@@ -10,6 +10,7 @@
                 id('https://www.github.com/${pipeline.org}/${pipeline.repo}.git')
                 remote('https://www.github.com/${pipeline.org}/${pipeline.repo}.git')
                 excludes('solution*')
+                shallowClone()
             }
         }
         orphanedItemStrategy {

--- a/modules/lead/product-jenkins/pipelines-git.tpl
+++ b/modules/lead/product-jenkins/pipelines-git.tpl
@@ -20,10 +20,9 @@
                     noTag(true)
                     depth(1)
                     reference()
-                    honorRefspec(false)
+                    honorRefspec(true)
                 }
             }
-            traitBlock << 'jenkins.plugins.git.traits.BranchDiscoveryTrait' {}
         }
         orphanedItemStrategy {
             discardOldItems {

--- a/modules/lead/product-jenkins/pipelines-git.tpl
+++ b/modules/lead/product-jenkins/pipelines-git.tpl
@@ -10,9 +10,11 @@
                 id('https://www.github.com/${pipeline.org}/${pipeline.repo}.git')
                 remote('https://www.github.com/${pipeline.org}/${pipeline.repo}.git')
                 excludes('solution*')
-                extensions {
-                    cloneOptions {
-                        shallow()
+                traits {
+                    cloneOptionTrait {
+                        extension {
+                            shallow(true)
+                        }
                     }
                 }
             }

--- a/modules/lead/product-jenkins/pipelines-git.tpl
+++ b/modules/lead/product-jenkins/pipelines-git.tpl
@@ -24,7 +24,7 @@
                 }
             }
             traitBlock << 'jenkins.plugins.git.traits.BranchDiscoveryTrait' {}
-            traitBlock << 'jenkins.plugins.git.traits.WildcardSCMHeadFilterTrait' {
+            traitBlock << 'jenkins.scm.impl.trait.WildcardSCMHeadFilterTrait' {
                 excludes('solution*')
             }
         }

--- a/modules/lead/product-jenkins/pipelines-git.tpl
+++ b/modules/lead/product-jenkins/pipelines-git.tpl
@@ -25,6 +25,7 @@
             }
             traitBlock << 'jenkins.plugins.git.traits.BranchDiscoveryTrait' {}
             traitBlock << 'jenkins.scm.impl.trait.WildcardSCMHeadFilterTrait' {
+                includes('*')
                 excludes('solution*')
             }
         }

--- a/modules/lead/product-jenkins/pipelines-git.tpl
+++ b/modules/lead/product-jenkins/pipelines-git.tpl
@@ -24,6 +24,9 @@
                 }
             }
             traitBlock << 'jenkins.plugins.git.traits.BranchDiscoveryTrait' {}
+            traitBlock << 'jenkins.plugins.git.traits.WildcardSCMHeadFilterTrait' {
+                excludes('solution*')
+            }
         }
         orphanedItemStrategy {
             discardOldItems {

--- a/modules/lead/product-jenkins/pipelines-git.tpl
+++ b/modules/lead/product-jenkins/pipelines-git.tpl
@@ -9,7 +9,6 @@
             git {
                 id('https://www.github.com/${pipeline.org}/${pipeline.repo}.git')
                 remote('https://www.github.com/${pipeline.org}/${pipeline.repo}.git')
-                excludes('solution*')
             }
         }
         configure {
@@ -17,7 +16,6 @@
             traitBlock << 'jenkins.plugins.git.traits.CloneOptionTrait' {
                 extension(class: 'hudson.plugins.git.extensions.impl.CloneOption') {
                     shallow(true)
-                    noTag(true)
                     depth(1)
                     reference()
                     honorRefspec(true)

--- a/modules/lead/product-jenkins/pipelines-git.tpl
+++ b/modules/lead/product-jenkins/pipelines-git.tpl
@@ -12,14 +12,6 @@
                 excludes('solution*')
             }
         }
-        configure {
-            def traitBlock = it / 'sources' / 'data' / 'jenkins.branch.BranchSource' / 'source' / 'traits'
-            traitBlock << 'jenkins.plugins.git.traits.CloneOptionTrait' {
-                extension(class: 'hudson.plugins.git.extensions.impl.CloneOption') {
-                    shallow(true)
-                }
-            }
-        }
         orphanedItemStrategy {
             discardOldItems {
                 numToKeep(20)

--- a/modules/lead/product-jenkins/pipelines-git.tpl
+++ b/modules/lead/product-jenkins/pipelines-git.tpl
@@ -10,12 +10,13 @@
                 id('https://www.github.com/${pipeline.org}/${pipeline.repo}.git')
                 remote('https://www.github.com/${pipeline.org}/${pipeline.repo}.git')
                 excludes('solution*')
-                traits {
-                    cloneOptionTrait {
-                        extension {
-                            shallow(true)
-                        }
-                    }
+            }
+        }
+        configure {
+            def traitBlock = it / 'sources' / 'data' / 'jenkins.branch.BranchSource' / 'source' / 'traits'
+            traitBlock << 'jenkins.plugins.git.traits.CloneOptionTrait' {
+                extension(class: 'hudson.plugins.git.extensions.impl.CloneOption') {
+                    shallow(true)
                 }
             }
         }

--- a/modules/lead/product-jenkins/pipelines-git.tpl
+++ b/modules/lead/product-jenkins/pipelines-git.tpl
@@ -23,6 +23,7 @@
                     honorRefspec(true)
                 }
             }
+            traitBlock << 'jenkins.plugins.git.traits.BranchDiscoveryTrait' {}
         }
         orphanedItemStrategy {
             discardOldItems {

--- a/modules/lead/product-jenkins/pipelines-git.tpl
+++ b/modules/lead/product-jenkins/pipelines-git.tpl
@@ -12,6 +12,19 @@
                 excludes('solution*')
             }
         }
+        configure {
+            def traitBlock = it / 'sources' / 'data' / 'jenkins.branch.BranchSource' / 'source' / 'traits'
+            traitBlock << 'jenkins.plugins.git.traits.CloneOptionTrait' {
+                extension(class: 'hudson.plugins.git.extensions.impl.CloneOption') {
+                    shallow(true)
+                    noTag(true)
+                    depth(1)
+                    reference()
+                    honorRefspec(false)
+                }
+            }
+            traitBlock << 'jenkins.plugins.git.traits.BranchDiscoveryTrait' {}
+        }
         orphanedItemStrategy {
             discardOldItems {
                 numToKeep(20)

--- a/modules/lead/product-jenkins/pipelines-git.tpl
+++ b/modules/lead/product-jenkins/pipelines-git.tpl
@@ -10,7 +10,7 @@
                 id('https://www.github.com/${pipeline.org}/${pipeline.repo}.git')
                 remote('https://www.github.com/${pipeline.org}/${pipeline.repo}.git')
                 excludes('solution*')
-                shallowClone()
+                shallow()
             }
         }
         orphanedItemStrategy {

--- a/modules/lead/product-jenkins/pipelines-git.tpl
+++ b/modules/lead/product-jenkins/pipelines-git.tpl
@@ -10,7 +10,11 @@
                 id('https://www.github.com/${pipeline.org}/${pipeline.repo}.git')
                 remote('https://www.github.com/${pipeline.org}/${pipeline.repo}.git')
                 excludes('solution*')
-                shallow()
+                extensions {
+                    cloneOptions {
+                        shallow()
+                    }
+                }
             }
         }
         orphanedItemStrategy {

--- a/modules/lead/product-jenkins/pod-templates.tpl
+++ b/modules/lead/product-jenkins/pod-templates.tpl
@@ -47,10 +47,10 @@ jenkins:
                   resources:
                     requests:
                       cpu: 50m
-                      memory: 256Mi
+                      memory: 128Mi
                     limits:
                       cpu: 500m
-                      memory: 512Mi
+                      memory: 256Mi
             yamlMergeStrategy: "merge"
           - name: "lead-toolchain-skaffold"
             label: "lead-toolchain-skaffold"

--- a/modules/lead/product-jenkins/pod-templates.tpl
+++ b/modules/lead/product-jenkins/pod-templates.tpl
@@ -26,8 +26,8 @@ jenkins:
                 ttyEnabled: true
                 resourceRequestCpu: 50m
                 resourceLimitCpu: 500m
-                resourceRequestMemory: 64Mi
-                resourceLimitMemory: 128Mi
+                resourceRequestMemory: 128Mi
+                resourceLimitMemory: 256Mi
             volumes:
               - hostPathVolume:
                   hostPath: "/var/run/docker.sock"

--- a/modules/lead/product-jenkins/pod-templates.tpl
+++ b/modules/lead/product-jenkins/pod-templates.tpl
@@ -47,7 +47,7 @@ jenkins:
                   resources:
                     requests:
                       cpu: 50m
-                      memory: 128Mi
+                      memory: 256Mi
                     limits:
                       cpu: 500m
                       memory: 512Mi

--- a/modules/lead/product-jenkins/pod-templates.tpl
+++ b/modules/lead/product-jenkins/pod-templates.tpl
@@ -34,7 +34,7 @@ jenkins:
                   mountPath: "/var/run/docker.sock"
               - secretVolume:
                   mountPath: "/root/.docker"
-                  secretName: "${jenkins-repository-dockercfg}"
+                  secretName: "${dockercfg_secret_name}"
             slaveConnectTimeout: 100
             serviceAccount: "jenkins"
             yaml: |-
@@ -80,7 +80,7 @@ jenkins:
                   mountPath: "/var/run/docker.sock"
               - secretVolume:
                   mountPath: "/root/.docker"
-                  secretName: "${jenkins-repository-dockercfg}"
+                  secretName: "${dockercfg_secret_name}"
             slaveConnectTimeout: 100
             serviceAccount: "jenkins"
             yaml: |-

--- a/modules/lead/product-jenkins/pod-templates.tpl
+++ b/modules/lead/product-jenkins/pod-templates.tpl
@@ -24,10 +24,10 @@ jenkins:
                 command: "/bin/sh -c"
                 args: "cat"
                 ttyEnabled: true
-                resourceRequestCpu: 50m
+                resourceRequestCpu: 100m
                 resourceLimitCpu: 500m
-                resourceRequestMemory: 64Mi
-                resourceLimitMemory: 128Mi
+                resourceRequestMemory: 128Mi
+                resourceLimitMemory: 256Mi
             volumes:
               - hostPathVolume:
                   hostPath: "/var/run/docker.sock"

--- a/modules/lead/product-jenkins/pod-templates.tpl
+++ b/modules/lead/product-jenkins/pod-templates.tpl
@@ -46,11 +46,11 @@ jenkins:
                 - name: jnlp
                   resources:
                     requests:
-                      cpu: 50m
-                      memory: 128Mi
+                      cpu: 100m
+                      memory: 256Mi
                     limits:
                       cpu: 500m
-                      memory: 256Mi
+                      memory: 512Mi
             yamlMergeStrategy: "merge"
           - name: "lead-toolchain-skaffold"
             label: "lead-toolchain-skaffold"

--- a/modules/lead/product-jenkins/pod-templates.tpl
+++ b/modules/lead/product-jenkins/pod-templates.tpl
@@ -26,8 +26,8 @@ jenkins:
                 ttyEnabled: true
                 resourceRequestCpu: 50m
                 resourceLimitCpu: 500m
-                resourceRequestMemory: 128Mi
-                resourceLimitMemory: 256Mi
+                resourceRequestMemory: 64Mi
+                resourceLimitMemory: 128Mi
             volumes:
               - hostPathVolume:
                   hostPath: "/var/run/docker.sock"

--- a/modules/lead/product-jenkins/pod-templates.tpl
+++ b/modules/lead/product-jenkins/pod-templates.tpl
@@ -24,10 +24,10 @@ jenkins:
                 command: "/bin/sh -c"
                 args: "cat"
                 ttyEnabled: true
-                resourceRequestCpu: 100m
+                resourceRequestCpu: 50m
                 resourceLimitCpu: 500m
-                resourceRequestMemory: 128Mi
-                resourceLimitMemory: 256Mi
+                resourceRequestMemory: 64Mi
+                resourceLimitMemory: 128Mi
             volumes:
               - hostPathVolume:
                   hostPath: "/var/run/docker.sock"
@@ -46,8 +46,8 @@ jenkins:
                 - name: jnlp
                   resources:
                     requests:
-                      cpu: 100m
-                      memory: 256Mi
+                      cpu: 50m
+                      memory: 128Mi
                     limits:
                       cpu: 500m
                       memory: 512Mi

--- a/modules/lead/product-jenkins/security-config.tpl
+++ b/modules/lead/product-jenkins/security-config.tpl
@@ -1,9 +1,0 @@
-jenkins:
-  authorizationStrategy:
-    loggedInUsersCanDoAnything:
-      %{~ if enable_keycloak }
-      allowAnonymousRead: "false"
-    securityRealm: keycloak
-      %{~ else }
-      allowAnonymousRead: "true"
-      %{~ endif }

--- a/modules/lead/product-jenkins/security-config.tpl
+++ b/modules/lead/product-jenkins/security-config.tpl
@@ -1,9 +1,7 @@
 jenkins:
   authorizationStrategy:
     loggedInUsersCanDoAnything:
-      %{~ if enable_keycloak }
-      allowAnonymousRead: "false"
-    securityRealm: keycloak
-      %{~ else }
-      allowAnonymousRead: "true"
-      %{~ endif }
+      allowAnonymousRead: ${!enable_keycloak}
+  %{~ if enable_keycloak }
+  securityRealm: keycloak
+  %{~ endif }

--- a/modules/lead/product-jenkins/security-config.tpl
+++ b/modules/lead/product-jenkins/security-config.tpl
@@ -1,5 +1,9 @@
 jenkins:
   authorizationStrategy:
     loggedInUsersCanDoAnything:
-      allowAnonymousRead: "${allow_anonymous_read}"
-  ${security_realm}
+      %{~ if enable_keycloak }
+      allowAnonymousRead: "false"
+    securityRealm: keycloak
+      %{~ else }
+      allowAnonymousRead: "true"
+      %{~ endif }

--- a/modules/lead/product-jenkins/security-config.tpl
+++ b/modules/lead/product-jenkins/security-config.tpl
@@ -1,0 +1,9 @@
+jenkins:
+  authorizationStrategy:
+    loggedInUsersCanDoAnything:
+      %{~ if enable_keycloak }
+      allowAnonymousRead: "false"
+    securityRealm: keycloak
+      %{~ else }
+      allowAnonymousRead: "true"
+      %{~ endif }

--- a/modules/lead/product-jenkins/slack-config.tpl
+++ b/modules/lead/product-jenkins/slack-config.tpl
@@ -1,4 +1,0 @@
-unclassified:
-  slackNotifier:
-    teamDomain: "${slack_team}"
-    tokenCredentialId: jenkins-credential-slack

--- a/modules/lead/product-jenkins/toolchain.tf
+++ b/modules/lead/product-jenkins/toolchain.tf
@@ -436,3 +436,24 @@ resource "kubernetes_config_map" "jcasc_controller_configmap" {
     "controller-node.yaml" = templatefile("${path.module}/controller.tpl", {})
   }
 }
+
+resource "kubernetes_config_map" "jcasc_security_configmap" {
+  provider = kubernetes.toolchain
+  metadata {
+    name      = "jenkins-jenkins-config-security-config"
+    namespace = module.toolchain_namespace.name
+
+    labels = {
+      "app.kubernetes.io/name"       = "jenkins"
+      "app.kubernetes.io/instance"   = "jenkins"
+      "app.kubernetes.io/component"  = "jenkins-controller"
+      "app.kubernetes.io/managed-by" = "Terraform"
+      "jenkins-jenkins-config"       = "true"
+    }
+  }
+  data = {
+    "security-config.yaml" = templatefile("${path.module}/security-config.tpl", {
+      enable_keycloak = var.enable_keycloak
+    })
+  }
+}

--- a/modules/lead/product-jenkins/toolchain.tf
+++ b/modules/lead/product-jenkins/toolchain.tf
@@ -68,6 +68,7 @@ resource "helm_release" "jenkins" {
       protocol              = local.protocol
       ssl_redirect          = local.protocol == "http" ? false : true
       ingress_hostname      = "${module.toolchain_namespace.name}.jenkins.${var.cluster_domain}"
+      enable_keycloak       = var.enable_keycloak
     })
   ]
 }
@@ -333,27 +334,6 @@ resource "kubernetes_config_map" "jcasc_shared_libraries_configmap" {
   }
   data = {
     "shared-libraries.yaml" = templatefile("${path.module}/shared-libraries.tpl", {})
-  }
-}
-
-resource "kubernetes_config_map" "jcasc_security_configmap" {
-  provider = kubernetes.toolchain
-  metadata {
-    name      = "jenkins-jenkins-config-security-config"
-    namespace = module.toolchain_namespace.name
-
-    labels = {
-      "app.kubernetes.io/name"       = "jenkins"
-      "app.kubernetes.io/instance"   = "jenkins"
-      "app.kubernetes.io/component"  = "jenkins-controller"
-      "app.kubernetes.io/managed-by" = "Terraform"
-      "jenkins-jenkins-config"       = "true"
-    }
-  }
-  data = {
-    "security-config.yaml" = templatefile("${path.module}/security-config.tpl", {
-      enable_keycloak = var.enable_keycloak
-    })
   }
 }
 

--- a/modules/lead/product-jenkins/toolchain.tf
+++ b/modules/lead/product-jenkins/toolchain.tf
@@ -67,7 +67,7 @@ resource "helm_release" "jenkins" {
       jenkins_image_version = var.jenkins_image_version
       protocol              = local.protocol
       ssl_redirect          = local.protocol == "http" ? false : true
-      ingress_hostname      = "${module.toolchain_namespace.name}.jenkins.${var.cluster_domain}"
+      ingress_hostname      = local.ingress_hostname
       enable_keycloak       = var.enable_keycloak
     })
   ]
@@ -433,7 +433,9 @@ resource "kubernetes_config_map" "jcasc_controller_configmap" {
     }
   }
   data = {
-    "controller-node.yaml" = templatefile("${path.module}/controller.tpl", {})
+    "controller-node.yaml" = templatefile("${path.module}/controller.tpl", {
+      root_url = "${local.protocol}://${local.ingress_hostname}"
+    })
   }
 }
 

--- a/modules/lead/product-jenkins/toolchain.tf
+++ b/modules/lead/product-jenkins/toolchain.tf
@@ -53,7 +53,7 @@ resource "helm_release" "jenkins" {
   repository = "https://charts.jenkins.io"
   namespace  = module.toolchain_namespace.name
   timeout    = "600"
-  version    = "1.6.0"
+  version    = "3.5.11"
 
   set_sensitive {
     name  = "master.adminPassword"

--- a/modules/lead/product-jenkins/toolchain.tf
+++ b/modules/lead/product-jenkins/toolchain.tf
@@ -33,7 +33,7 @@ resource "kubernetes_service_account" "jenkins" {
     labels = {
       "app.kubernetes.io/name"       = "jenkins"
       "app.kubernetes.io/instance"   = "jenkins"
-      "app.kubernetes.io/component"  = "jenkins-master"
+      "app.kubernetes.io/component"  = "jenkins-controller"
       "app.kubernetes.io/managed-by" = "Terraform"
     }
 
@@ -56,7 +56,7 @@ resource "helm_release" "jenkins" {
   version    = "3.5.11"
 
   set_sensitive {
-    name  = "master.adminPassword"
+    name  = "controller.adminPassword"
     value = random_password.jenkins_admin_password.result
   }
 
@@ -82,7 +82,7 @@ resource "kubernetes_role" "jenkins_kubernetes_credentials" {
     labels = {
       "app.kubernetes.io/name"       = "jenkins"
       "app.kubernetes.io/instance"   = "jenkins"
-      "app.kubernetes.io/component"  = "jenkins-master"
+      "app.kubernetes.io/component"  = "jenkins-controller"
       "app.kubernetes.io/managed-by" = "Terraform"
     }
 
@@ -148,7 +148,7 @@ resource "kubernetes_role_binding" "jenkins_kubernetes_credentials" {
     labels = {
       "app.kubernetes.io/name"       = "jenkins"
       "app.kubernetes.io/instance"   = "jenkins"
-      "app.kubernetes.io/component"  = "jenkins-master"
+      "app.kubernetes.io/component"  = "jenkins-controller"
       "app.kubernetes.io/managed-by" = "Terraform"
     }
 
@@ -179,7 +179,7 @@ resource "kubernetes_cluster_role" "jenkins_kubernetes_credentials" {
     labels = {
       "app.kubernetes.io/name"       = "jenkins"
       "app.kubernetes.io/instance"   = "jenkins"
-      "app.kubernetes.io/component"  = "jenkins-master"
+      "app.kubernetes.io/component"  = "jenkins-controller"
       "app.kubernetes.io/managed-by" = "Terraform"
     }
 
@@ -212,7 +212,7 @@ resource "kubernetes_cluster_role_binding" "jenkins_kubernetes_credentials" {
     labels = {
       "app.kubernetes.io/name"       = "jenkins"
       "app.kubernetes.io/instance"   = "jenkins"
-      "app.kubernetes.io/component"  = "jenkins-master"
+      "app.kubernetes.io/component"  = "jenkins-controller"
       "app.kubernetes.io/managed-by" = "Terraform"
     }
 
@@ -244,7 +244,7 @@ resource "kubernetes_role_binding" "jenkins_staging_rolebinding" {
     labels = {
       "app.kubernetes.io/name"       = "jenkins"
       "app.kubernetes.io/instance"   = "jenkins"
-      "app.kubernetes.io/component"  = "jenkins-master"
+      "app.kubernetes.io/component"  = "jenkins-controller"
       "app.kubernetes.io/managed-by" = "Terraform"
     }
 
@@ -276,7 +276,7 @@ resource "kubernetes_role_binding" "jenkins_production_rolebinding" {
     labels = {
       "app.kubernetes.io/name"       = "jenkins"
       "app.kubernetes.io/instance"   = "jenkins"
-      "app.kubernetes.io/component"  = "jenkins-master"
+      "app.kubernetes.io/component"  = "jenkins-controller"
       "app.kubernetes.io/managed-by" = "Terraform"
     }
 
@@ -326,7 +326,7 @@ resource "kubernetes_config_map" "jcasc_shared_libraries_configmap" {
     labels = {
       "app.kubernetes.io/name"       = "jenkins"
       "app.kubernetes.io/instance"   = "jenkins"
-      "app.kubernetes.io/component"  = "jenkins-master"
+      "app.kubernetes.io/component"  = "jenkins-controller"
       "app.kubernetes.io/managed-by" = "Terraform"
       "jenkins-jenkins-config"       = "true"
     }
@@ -345,7 +345,7 @@ resource "kubernetes_config_map" "jcasc_security_configmap" {
     labels = {
       "app.kubernetes.io/name"       = "jenkins"
       "app.kubernetes.io/instance"   = "jenkins"
-      "app.kubernetes.io/component"  = "jenkins-master"
+      "app.kubernetes.io/component"  = "jenkins-controller"
       "app.kubernetes.io/managed-by" = "Terraform"
       "jenkins-jenkins-config"       = "true"
     }
@@ -366,7 +366,7 @@ resource "kubernetes_config_map" "jcasc_pod_templates_configmap" {
     labels = {
       "app.kubernetes.io/name"       = "jenkins"
       "app.kubernetes.io/instance"   = "jenkins"
-      "app.kubernetes.io/component"  = "jenkins-master"
+      "app.kubernetes.io/component"  = "jenkins-controller"
       "app.kubernetes.io/managed-by" = "Terraform"
       "jenkins-jenkins-config"       = "true"
     }
@@ -393,7 +393,7 @@ resource "kubernetes_config_map" "jcasc_env_configmap" {
     labels = {
       "app.kubernetes.io/name"       = "jenkins"
       "app.kubernetes.io/instance"   = "jenkins"
-      "app.kubernetes.io/component"  = "jenkins-master"
+      "app.kubernetes.io/component"  = "jenkins-controller"
       "app.kubernetes.io/managed-by" = "Helm"
       "helm.sh/chart"                = "jenkins-1.6.0"
       "jenkins-jenkins-config"       = "true"
@@ -421,7 +421,7 @@ resource "kubernetes_config_map" "jcasc_keycloak_config_configmap" {
     labels = {
       "app.kubernetes.io/name"       = "jenkins"
       "app.kubernetes.io/instance"   = "jenkins"
-      "app.kubernetes.io/component"  = "jenkins-master"
+      "app.kubernetes.io/component"  = "jenkins-controller"
       "app.kubernetes.io/managed-by" = "Terraform"
       "jenkins-jenkins-config"       = "true"
     }
@@ -438,21 +438,21 @@ resource "kubernetes_config_map" "jcasc_keycloak_config_configmap" {
   }
 }
 
-resource "kubernetes_config_map" "jcasc_master_node_configmap" {
+resource "kubernetes_config_map" "jcasc_controller_configmap" {
   provider = kubernetes.toolchain
   metadata {
-    name      = "jenkins-jenkins-config-master-node"
+    name      = "jenkins-jenkins-config-controller"
     namespace = module.toolchain_namespace.name
 
     labels = {
       "app.kubernetes.io/name"       = "jenkins"
       "app.kubernetes.io/instance"   = "jenkins"
-      "app.kubernetes.io/component"  = "jenkins-master"
+      "app.kubernetes.io/component"  = "jenkins-controller"
       "app.kubernetes.io/managed-by" = "Terraform"
       "jenkins-jenkins-config"       = "true"
     }
   }
   data = {
-    "master-node.yaml" = templatefile("${path.module}/master-node.tpl", {})
+    "controller-node.yaml" = templatefile("${path.module}/controller.tpl", {})
   }
 }

--- a/modules/lead/product-jenkins/toolchain.tf
+++ b/modules/lead/product-jenkins/toolchain.tf
@@ -7,41 +7,6 @@ module "essential_tolerations" {
   source = "../../affinity/essential-toleration-values"
 }
 
-data "template_file" "jenkins_values" {
-  template = file("${path.module}/jenkins-values.tpl")
-
-  vars = {
-    cluster_domain               = var.cluster_domain
-    toolchain_image_repo         = var.toolchain_image_repo
-    jenkins_image_version        = var.jenkins_image_version
-    product_name                 = var.product_name
-    protocol                     = local.protocol
-    ssl_redirect                 = local.protocol == "http" ? false : true
-    product_image_repo           = var.product_image_repo
-    ingress_hostname             = "${module.toolchain_namespace.name}.jenkins.${var.cluster_domain}"
-    namespace                    = module.toolchain_namespace.name
-    toolchain_namespace          = var.toolchain_namespace
-    logstash_url                 = "http://lead-dashboard-logstash.toolchain.svc.cluster.local:9000"
-    slack_team                   = "liatrio"
-    stagingNamespace             = module.product_base.staging_namespace
-    productionNamespace          = module.product_base.production_namespace
-    databaseNamespace            = module.product_base.database_namespace
-    appDomain                    = "apps.${var.cluster_domain}"
-    builder_images_version       = var.builder_images_version
-    allow_anonymous_read         = var.enable_keycloak ? "false" : "true"
-    jenkins-repository-dockercfg = kubernetes_secret.jenkins_repository_dockercfg.metadata[0].name
-
-
-    # Keycloak specific vars
-    security_realm = var.enable_keycloak ? "securityRealm: keycloak" : ""
-    keycloak_ssl   = local.protocol == "http" ? "none" : "external"
-    # keycloak_url must be accessible from both inside and outside the cluster.
-    # For local environment, you'll need to add this line to your hosts file...
-    # [YOUR_HOST_INTERNAL_IP_NOT_127.0.0.1]   keycloak.toolchain.docker-for-desktop.localhost
-    keycloak_url = "${local.protocol}://keycloak.toolchain.${var.cluster_domain}/auth"
-  }
-}
-
 module "toolchain_namespace" {
   source    = "../../common/namespace"
   namespace = "${var.product_name}-toolchain"
@@ -59,25 +24,6 @@ module "toolchain_namespace" {
   }
 }
 
-resource "helm_release" "jenkins" {
-  provider   = helm.toolchain
-  name       = "jenkins"
-  chart      = "jenkins"
-  repository = "https://charts.jenkins.io"
-  namespace  = module.toolchain_namespace.name
-  timeout    = "600"
-  version    = "1.6.0"
-
-  set_sensitive {
-    name  = "master.adminPassword"
-    value = random_password.jenkins_admin_password.result
-  }
-
-  values = [
-  data.template_file.jenkins_values.rendered]
-}
-
-// Create Jenkins service account
 resource "kubernetes_service_account" "jenkins" {
   provider = kubernetes.toolchain
   metadata {
@@ -98,6 +44,32 @@ resource "kubernetes_service_account" "jenkins" {
   }
 
   automount_service_account_token = true
+}
+
+resource "helm_release" "jenkins" {
+  provider   = helm.toolchain
+  name       = "jenkins"
+  chart      = "jenkins"
+  repository = "https://charts.jenkins.io"
+  namespace  = module.toolchain_namespace.name
+  timeout    = "600"
+  version    = "1.6.0"
+
+  set_sensitive {
+    name  = "master.adminPassword"
+    value = random_password.jenkins_admin_password.result
+  }
+
+  values = [
+    templatefile("${path.module}/jenkins-values.tpl", {
+      service_account_name  = kubernetes_service_account.jenkins.metadata[0].name
+      toolchain_image_repo  = var.toolchain_image_repo
+      jenkins_image_version = var.jenkins_image_version
+      protocol              = local.protocol
+      ssl_redirect          = local.protocol == "http" ? false : true
+      ingress_hostname      = "${module.toolchain_namespace.name}.jenkins.${var.cluster_domain}"
+    })
+  ]
 }
 
 // Add role to allow Jenkins to read secrets
@@ -122,38 +94,47 @@ resource "kubernetes_role" "jenkins_kubernetes_credentials" {
 
   rule {
     api_groups = [
-    ""]
+      ""
+    ]
     resources = [
-    "secrets"]
+      "secrets"
+    ]
     verbs = [
       "get",
       "watch",
-    "list"]
+      "list",
+    ]
   }
   rule {
     api_groups = [
       "stable.liatr.io",
-    "sdm.liatr.io"]
+      "sdm.liatr.io",
+    ]
     resources = [
-    "builds"]
+      "builds"
+    ]
     verbs = [
       "create",
       "update",
       "patch",
       "get",
       "watch",
-    "list"]
+      "list",
+    ]
   }
   rule {
     api_groups = [
-    ""]
+      ""
+    ]
     resources = [
-    "events"]
+      "events"
+    ]
     verbs = [
       "create",
       "get",
       "watch",
-    "list"]
+      "list",
+    ]
   }
 }
 
@@ -210,13 +191,16 @@ resource "kubernetes_cluster_role" "jenkins_kubernetes_credentials" {
 
   rule {
     api_groups = [
-    "apiextensions.k8s.io"]
+      "apiextensions.k8s.io"
+    ]
     resources = [
-    "customresourcedefinitions"]
+      "customresourcedefinitions"
+    ]
     verbs = [
       "create",
       "get",
-    "list"]
+      "list",
+    ]
   }
 }
 
@@ -367,7 +351,9 @@ resource "kubernetes_config_map" "jcasc_security_configmap" {
     }
   }
   data = {
-    "shared-libraries.yaml" = templatefile("${path.module}/security-config.tpl", data.template_file.jenkins_values.vars)
+    "security-config.yaml" = templatefile("${path.module}/security-config.tpl", {
+      enable_keycloak = var.enable_keycloak
+    })
   }
 }
 
@@ -386,28 +372,15 @@ resource "kubernetes_config_map" "jcasc_pod_templates_configmap" {
     }
   }
   data = {
-    "pod-templates.yaml" = templatefile("${path.module}/pod-templates.tpl", merge(data.template_file.jenkins_values.vars, {
-      essential_tolerations = module.essential_tolerations.values
-    }))
-  }
-}
-
-resource "kubernetes_config_map" "jcasc_slack_config_configmap" {
-  provider = kubernetes.toolchain
-  metadata {
-    name      = "jenkins-jenkins-config-slack-config"
-    namespace = module.toolchain_namespace.name
-
-    labels = {
-      "app.kubernetes.io/name"       = "jenkins"
-      "app.kubernetes.io/instance"   = "jenkins"
-      "app.kubernetes.io/component"  = "jenkins-master"
-      "app.kubernetes.io/managed-by" = "Terraform"
-      "jenkins-jenkins-config"       = "true"
-    }
-  }
-  data = {
-    "slack-config.yaml" = templatefile("${path.module}/slack-config.tpl", data.template_file.jenkins_values.vars)
+    "pod-templates.yaml" = templatefile("${path.module}/pod-templates.tpl", {
+      essential_tolerations  = module.essential_tolerations.values
+      namespace              = module.toolchain_namespace.name
+      dockercfg_secret_name  = kubernetes_secret.jenkins_repository_dockercfg.metadata[0].name
+      toolchain_image_repo   = var.toolchain_image_repo
+      product_image_repo     = var.product_image_repo
+      product_name           = var.product_name
+      builder_images_version = var.builder_images_version
+    })
   }
 }
 
@@ -427,7 +400,15 @@ resource "kubernetes_config_map" "jcasc_env_configmap" {
     }
   }
   data = {
-    "env.yaml" = templatefile("${path.module}/jenkins-env.tpl", data.template_file.jenkins_values.vars)
+    "env.yaml" = templatefile("${path.module}/jenkins-env.tpl", {
+      logstash_url        = "http://lead-dashboard-logstash.toolchain.svc.cluster.local:9000"
+      stagingNamespace    = module.product_base.staging_namespace
+      productionNamespace = module.product_base.production_namespace
+      databaseNamespace   = module.product_base.database_namespace
+      toolchain_namespace = var.toolchain_namespace
+      appDomain           = "apps.${var.cluster_domain}"
+      product_name        = var.product_name
+    })
   }
 }
 
@@ -446,7 +427,14 @@ resource "kubernetes_config_map" "jcasc_keycloak_config_configmap" {
     }
   }
   data = {
-    "keycloak-config.yaml" = templatefile("${path.module}/keycloak-config.tpl", data.template_file.jenkins_values.vars)
+    "keycloak-config.yaml" = templatefile("${path.module}/keycloak-config.tpl", {
+      ingress_hostname = "${module.toolchain_namespace.name}.jenkins.${var.cluster_domain}"
+      keycloak_ssl     = local.protocol == "http" ? "none" : "external"
+      # keycloak_url must be accessible from both inside and outside the cluster.
+      # For local environment, you'll need to add this line to your hosts file...
+      # [YOUR_HOST_INTERNAL_IP_NOT_127.0.0.1]   keycloak.toolchain.docker-for-desktop.localhost
+      keycloak_url     = "${local.protocol}://keycloak.toolchain.${var.cluster_domain}/auth"
+    })
   }
 }
 


### PR DESCRIPTION
this PR upgrades the jenkins chart helm chart within the jenkins product to the latest version, and fixes a potential issue with downloading large git repositories by performing a shallow clone.

the contents of this PR should be used with https://github.com/liatrio/builder-images/pull/77