### PR TITLE
Deploy Harbor collector

### DIFF
--- a/modules/config/harbor/main.tf
+++ b/modules/config/harbor/main.tf
@@ -63,7 +63,7 @@ resource "helm_release" "harbor_config" {
 resource "harbor_project" "liatrio_project" {
   name      = "liatrio"
   public    = true
-  auto_scan = false
+  auto_scan = var.autoscan_images
 }
 
 resource "harbor_robot_account" "liatrio_project_robot_account" {
@@ -90,5 +90,17 @@ resource "kubernetes_secret" "liatrio_project_robot_account_credentials" {
   data = {
     username = harbor_robot_account.liatrio_project_robot_account.name
     password = harbor_robot_account.liatrio_project_robot_account.token
+  }
+}
+
+resource "harbor_webhook" "webhook" {
+  for_each = var.webhooks
+
+  project_id  = harbor_project.liatrio_project.id
+  name        = title(each.key)
+  event_types = each.value.event_types
+  target {
+    type    = "http"
+    address = each.value.webhook_url
   }
 }

--- a/modules/config/harbor/variables.tf
+++ b/modules/config/harbor/variables.tf
@@ -11,3 +11,12 @@ variable "enable_keycloak" {
 variable "keycloak_hostname" {}
 
 variable "keycloak_realm" {}
+
+variable "autoscan_images" {
+  default = false
+}
+
+variable "webhooks" {
+  type    = map(any)
+  default = {}
+}

--- a/modules/tools/rode/harbor-collector-values.yaml.tpl
+++ b/modules/tools/rode/harbor-collector-values.yaml.tpl
@@ -1,0 +1,12 @@
+rode:
+  host: rode.${namespace}.svc.cluster.local:50051
+  disableTransportSecurity: true
+
+  auth:
+    oidc:
+      enabled: ${oidc_auth_enabled}
+      clientId: ${oidc_client_id}
+      tokenUrl: ${oidc_token_url}
+
+harbor:
+  host: ${harbor_url}

--- a/modules/tools/rode/main.tf
+++ b/modules/tools/rode/main.tf
@@ -143,7 +143,7 @@ resource "helm_release" "rode_collector_harbor" {
   namespace  = var.namespace
   chart      = "rode-collector-harbor"
   repository = "https://rode.github.io/charts"
-  version    = "0.2.1"
+  version    = "0.2.0"
   wait       = true
 
   set_sensitive {

--- a/modules/tools/rode/main.tf
+++ b/modules/tools/rode/main.tf
@@ -138,6 +138,30 @@ resource "helm_release" "rode_sonarqube_collector" {
   ]
 }
 
+resource "helm_release" "rode_collector_harbor" {
+  name       = "rode-collector-harbor"
+  namespace  = var.namespace
+  chart      = "rode-collector-harbor"
+  repository = "https://rode.github.io/charts"
+  version    = "0.2.1"
+  wait       = true
+
+  set_sensitive {
+    name  = "rode.auth.oidc.clientSecret"
+    value = var.collector_client_secret
+  }
+
+  values = [
+    templatefile("${path.module}/harbor-collector-values.yaml.tpl", {
+      namespace         = var.namespace
+      harbor_url        = var.harbor_url
+      oidc_auth_enabled = local.auth_enabled
+      oidc_client_id    = var.collector_client_id
+      oidc_token_url    = var.oidc_token_url
+    })
+  ]
+}
+
 resource "helm_release" "rode_build_collector" {
   name       = "rode-collector-build"
   namespace  = var.namespace

--- a/modules/tools/rode/variables.tf
+++ b/modules/tools/rode/variables.tf
@@ -68,3 +68,7 @@ variable "collector_client_secret" {
   type      = string
   sensitive = true
 }
+
+variable "harbor_url" {
+  type = string
+}

--- a/stages/apps/sharedsvc/harbor.tf
+++ b/stages/apps/sharedsvc/harbor.tf
@@ -2,6 +2,10 @@ data "vault_generic_secret" "harbor" {
   path = "lead/aws/${data.aws_caller_identity.current.account_id}/harbor"
 }
 
+locals {
+  harbor_hostname = "harbor.${var.cluster_domain}"
+}
+
 module "harbor_namespace" {
   source    = "../../../modules/common/namespace"
   namespace = "harbor"
@@ -10,7 +14,7 @@ module "harbor_namespace" {
 module "harbor" {
   source = "../../../modules/tools/harbor"
 
-  harbor_ingress_hostname      = "harbor.${var.cluster_domain}"
+  harbor_ingress_hostname      = local.harbor_hostname
   notary_ingress_hostname      = "notary.${var.cluster_domain}"
   ingress_annotations          = local.common_ingress_annotations
   namespace                    = module.harbor_namespace.name

--- a/stages/apps/sharedsvc/outputs.tf
+++ b/stages/apps/sharedsvc/outputs.tf
@@ -38,6 +38,10 @@ output "sonarqube_collector_url" {
   value = "http://rode-collector-sonarqube.${module.rode_namespace.name}.svc.cluster.local/webhook/event"
 }
 
+output "harbor_collector_url" {
+  value = "http://rode-collector-harbor.${module.rode_namespace.name}.svc.cluster.local/webhook/event"
+}
+
 output "rode_oidc_client_id" {
   value = local.rode_oidc_client_id
 }

--- a/stages/apps/sharedsvc/rode.tf
+++ b/stages/apps/sharedsvc/rode.tf
@@ -33,6 +33,7 @@ module "rode" {
   build_collector_hostname      = local.build_collector_hostname
   build_collector_grpc_hostname = local.build_collector_grpc_hostname
   tfsec_collector_hostname      = local.tfsec_collector_hostname
+  harbor_url                    = "https://${local.harbor_hostname}"
 
   oidc_issuer_url    = local.keycloak_issuer_uri
   oidc_token_url     = local.keycloak_token_uri

--- a/stages/config/sharedsvc/harbor.tf
+++ b/stages/config/sharedsvc/harbor.tf
@@ -9,6 +9,13 @@ module "harbor_config" {
   hostname          = var.harbor_hostname
   admin_password    = data.vault_generic_secret.harbor.data["admin-password"]
   enable_keycloak   = true
+  autoscan_images   = true
   keycloak_hostname = var.keycloak_hostname
   keycloak_realm    = keycloak_realm.sharedsvc.id
+  webhooks = {
+    "rode" : {
+      "event_types" : ["SCANNING_COMPLETED", "SCANNING_FAILED"],
+      "webhook_url" : var.harbor_collector_url,
+    }
+  }
 }

--- a/stages/config/sharedsvc/variables.tf
+++ b/stages/config/sharedsvc/variables.tf
@@ -21,3 +21,5 @@ variable "rode_hostname" {}
 variable "rode_ui_hostname" {}
 
 variable "sonarqube_collector_url" {}
+
+variable "harbor_collector_url" {}


### PR DESCRIPTION
It's worth mentioning that this isn't the latest and greatest version of the collector, instead it's a patch version behind so that it's compatible with the version of Harbor that's in use. See https://github.com/rode/collector-harbor/pull/19 for more details. 

If we upgrade Harbor, we'll need to bump the collector as well. 