### PR TITLE
allow non-prod admin to use vault

### DIFF
--- a/stages/vault/sharedsvc/vault.tf
+++ b/stages/vault/sharedsvc/vault.tf
@@ -7,6 +7,8 @@ locals {
   sharedsvc_aws_account  = "265560927720"
   remote_k8s_aws_account = "210831435012"
   rtx_aws_account        = "702109968614"
+
+  vault_token_ttl_thirty_minutes = 60 * 30
 }
 
 resource "vault_auth_backend" "aws" {
@@ -24,6 +26,9 @@ resource "vault_aws_auth_backend_role" "vault_admin" {
   token_policies = [
     vault_policy.vault_admin.name
   ]
+
+  token_ttl     = local.vault_token_ttl_thirty_minutes
+  token_max_ttl = local.vault_token_ttl_thirty_minutes
 }
 
 resource "vault_aws_auth_backend_role" "gpg_aws_admin" {
@@ -37,6 +42,9 @@ resource "vault_aws_auth_backend_role" "gpg_aws_admin" {
   token_policies = [
     vault_policy.gpg_aws_admin.name
   ]
+
+  token_ttl     = local.vault_token_ttl_thirty_minutes
+  token_max_ttl = local.vault_token_ttl_thirty_minutes
 }
 
 resource "vault_aws_auth_backend_role" "aws_admin" {
@@ -56,6 +64,9 @@ resource "vault_aws_auth_backend_role" "aws_admin" {
     vault_policy.lead_aws_admin.name,
     vault_policy.openstack_aws_admin.name
   ]
+
+  token_ttl     = local.vault_token_ttl_thirty_minutes
+  token_max_ttl = local.vault_token_ttl_thirty_minutes
 }
 
 resource "vault_aws_auth_backend_role" "aws_developer" {
@@ -74,4 +85,7 @@ resource "vault_aws_auth_backend_role" "aws_developer" {
   token_policies = [
     vault_policy.lead_aws_developer.name
   ]
+
+  token_ttl     = local.vault_token_ttl_thirty_minutes
+  token_max_ttl = local.vault_token_ttl_thirty_minutes
 }

--- a/stages/vault/sharedsvc/vault.tf
+++ b/stages/vault/sharedsvc/vault.tf
@@ -2,6 +2,7 @@
 
 locals {
   prod_aws_account       = "489130170427"
+  non_prod_aws_account   = "281127131043"
   sandbox_aws_account    = "774051255656"
   sharedsvc_aws_account  = "265560927720"
   remote_k8s_aws_account = "210831435012"
@@ -44,6 +45,7 @@ resource "vault_aws_auth_backend_role" "aws_admin" {
   auth_type = "iam"
   bound_iam_principal_arns = formatlist("arn:aws:iam::%s:role/Administrator", [
     local.prod_aws_account,
+    local.non_prod_aws_account,
     local.sandbox_aws_account,
     local.remote_k8s_aws_account,
     local.rtx_aws_account,
@@ -62,6 +64,7 @@ resource "vault_aws_auth_backend_role" "aws_developer" {
   auth_type = "iam"
   bound_iam_principal_arns = formatlist("arn:aws:iam::%s:role/Developer", [
     local.prod_aws_account,
+    local.non_prod_aws_account,
     local.sandbox_aws_account,
     local.remote_k8s_aws_account,
     local.rtx_aws_account,


### PR DESCRIPTION
also set the max token ttl to thirty minutes

I already applied this change so I can continue with setting up the nonprod environment