### PR TITLE
fix: update usage of kube-prometheus-stack module in sharedsvc to include new required arguments

### DIFF
--- a/modules/tools/github-actions-runners/main.tf
+++ b/modules/tools/github-actions-runners/main.tf
@@ -21,4 +21,3 @@ resource "helm_release" "github_runners" {
     })
   ]
 }
-

--- a/stages/apps/sharedsvc/kube-prometheus-stack.tf
+++ b/stages/apps/sharedsvc/kube-prometheus-stack.tf
@@ -3,8 +3,8 @@ data "vault_generic_secret" "prometheus" {
 }
 
 module "monitoring_namespace" {
-  source    = "../../../modules/common/namespace"
-  namespace = var.monitoring_namespace
+  source      = "../../../modules/common/namespace"
+  namespace   = var.monitoring_namespace
   annotations = {
     name    = var.monitoring_namespace
     cluster = var.eks_cluster_id
@@ -14,11 +14,13 @@ module "monitoring_namespace" {
 module "kube_prometheus_stack" {
   source = "../../../modules/tools/kube-prometheus-stack"
 
-  namespace                    = module.monitoring_namespace.name
-  grafana_hostname             = "grafana.${var.internal_cluster_domain}"
-  prometheus_slack_webhook_url = data.vault_generic_secret.prometheus.data["slack-webhook-url"]
-  prometheus_slack_channel     = var.prometheus_slack_channel
-  ingress_annotations          = local.external_ingress_annotations
+  namespace                        = module.monitoring_namespace.name
+  grafana_hostname                 = "grafana.${var.internal_cluster_domain}"
+  alertmanager_hostname            = "alertmanager.${var.internal_cluster_domain}"
+  prometheus_slack_webhook_url     = data.vault_generic_secret.prometheus.data["slack-webhook-url"]
+  prometheus_slack_channel         = var.prometheus_slack_channel
+  grafana_ingress_annotations      = local.internal_ingress_annotations
+  alertmanager_ingress_annotations = local.internal_ingress_annotations
 }
 
 module "dashboard" {

--- a/stages/apps/sharedsvc/kube-prometheus-stack.tf
+++ b/stages/apps/sharedsvc/kube-prometheus-stack.tf
@@ -3,8 +3,8 @@ data "vault_generic_secret" "prometheus" {
 }
 
 module "monitoring_namespace" {
-  source      = "../../../modules/common/namespace"
-  namespace   = var.monitoring_namespace
+  source    = "../../../modules/common/namespace"
+  namespace = var.monitoring_namespace
   annotations = {
     name    = var.monitoring_namespace
     cluster = var.eks_cluster_id

--- a/stages/apps/sharedsvc/main.tf
+++ b/stages/apps/sharedsvc/main.tf
@@ -19,6 +19,12 @@ locals {
     "nginx.ingress.kubernetes.io/proxy-body-size" : "0"
     "kubernetes.io/ingress.class" : module.nginx_external.ingress_class
   }
+
+  internal_ingress_annotations = {
+    "nginx.ingress.kubernetes.io/force-ssl-redirect" : true
+    "nginx.ingress.kubernetes.io/proxy-body-size" : "0"
+    "kubernetes.io/ingress.class" : module.nginx.ingress_class
+  }
 }
 
 provider "kubernetes" {


### PR DESCRIPTION
I can't run plan/apply on sharedsvc against master without these changes.