### PR TITLE
Silence alert down alert

### DIFF
--- a/modules/tools/kube-prometheus-stack/values.tpl
+++ b/modules/tools/kube-prometheus-stack/values.tpl
@@ -140,6 +140,11 @@ alertmanager:
        - match:
           alertname: KubeMemOvercommit
         receiver: "null"
+      # Ignoring target down alert because of an issue with aws 
+      # issue: https://github.com/aws/containers-roadmap/issues/657
+      - match: 
+          alertname: TargetDown
+        receiver: "null"
     templates:
     - /etc/alertmanager/config/template*.tmpl
     receivers:

--- a/modules/tools/kube-prometheus-stack/values.tpl
+++ b/modules/tools/kube-prometheus-stack/values.tpl
@@ -137,6 +137,9 @@ alertmanager:
       - match:
           alertname: KubeCPUOvercommit
         receiver: "null"
+       - match:
+          alertname: KubeMemOvercommit
+        receiver: "null"
     templates:
     - /etc/alertmanager/config/template*.tmpl
     receivers:


### PR DESCRIPTION
- Silencing target down alert because of an issue with aws: [](https://github.com/aws/containers-roadmap/issues/657)