### PR TITLE
ci: require PR titles to use conventional commit prefixes

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -16,3 +16,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           validateSingleCommit: true
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            revert


### PR DESCRIPTION
Adds a GitHub Action workflow to enforce that pull request titles use [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) prefixes. If a PR has a single commit, then it also requires the commit to follow the convention, since GitHub will suggest the commit for the title when squash merging. 

By default, it uses the standard list of prefixes, although that can be overwritten:

 - feat
 - fix
 - docs
 - style
 - refactor
 - perf
 - test
 - build
 - ci
 - chore
 - revert

The action also supports validating scopes, but I didn't configure that for now. If there's a convention we want to enforce, then it should be flexible enough to accommodate that. 

Here's a few pull requests that demonstrate the action:
- mix of failing/successful statuses when editing PR title: https://github.com/alexashley/lead-terraform/pull/1
- check that single commits fail without a prefix: https://github.com/alexashley/lead-terraform/pull/3