### PR TITLE
ci: open a PR to bump lead-environments after a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,4 +52,5 @@ jobs:
         with:
           repo: ${{ github.repository_owner }}/lead-environments
           token: ${{ secrets.GITTY_UP_TOKEN }}
-          message: "build: update lead-terraform from ${{ needs.release.outputs.previousVersion }} to ${{ needs.release.outputs.newVersion }}"
+          commit-prefix: "build"
+          message: "update lead-terraform from ${{ needs.release.outputs.previousVersion }} to ${{ needs.release.outputs.newVersion }}"


### PR DESCRIPTION
Depends on https://github.com/liatrio/lead-environments/pull/614 being merged first. 

Here's an example [run](https://github.com/alexashley/lead-terraform/runs/3956101077?check_suite_focus=true) in my fork that produced this PR: https://github.com/alexashley/lead-environments/pull/2 

And a [run](https://github.com/alexashley/lead-terraform/actions/runs/1365083874) where the release didn't create a new version, so the update workflow didn't execute. 