### PR TITLE
ci: prevent concurrent release workflow runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ on:
 
 concurrency:
   group: release
-  cancel-in-progress: true
 
 jobs:
   release:


### PR DESCRIPTION
Adds a [concurrency group](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency) to the release workflow so that only a single run happens at a time. 