### PR TITLE
fix: bump fluent bit resources

### DIFF
--- a/modules/tools/fluent-bit/values.tpl
+++ b/modules/tools/fluent-bit/values.tpl
@@ -25,5 +25,5 @@ resources:
     cpu: 300m
     memory: 100Mi
   requests:
-    cpu: 100m
-    memory: 50Mi
+    cpu: 75m
+    memory: 24Mi


### PR DESCRIPTION
- Bump cpu requests to bring down cpu throttling %
- Bump memory requests. 
- Lower memory limit because the fluent-bit pod is no using anywhere close to the memory limit. 