### PR TITLE
fix: wait as long as it takes for the vcluster to be online and reachable

### DIFF
--- a/stages/vcluster/aws.tf
+++ b/stages/vcluster/aws.tf
@@ -4,7 +4,7 @@ data "tls_certificate" "vcluster_api_server_cert" {
   verify_chain = false
 
   depends_on = [
-    time_sleep.wait_for_vcluster
+    module.wait_for_vcluster
   ]
 }
 

--- a/stages/vcluster/versions.tf
+++ b/stages/vcluster/versions.tf
@@ -13,10 +13,6 @@ terraform {
       source  = "hashicorp/aws"
       version = "3.63.0"
     }
-    time = {
-      source  = "hashicorp/time"
-      version = "0.7.2"
-    }
     tls = {
       source  = "hashicorp/tls"
       version = "3.1.0"

--- a/stages/vcluster/virtual_cluster.tf
+++ b/stages/vcluster/virtual_cluster.tf
@@ -52,7 +52,7 @@ resource "kubernetes_cluster_role_binding" "oidc_viewer" {
   }
 
   depends_on = [
-    time_sleep.wait_for_vcluster,
+    module.wait_for_vcluster,
     data.kubernetes_secret.vcluster_kubeconfig
   ]
 }
@@ -82,7 +82,7 @@ resource "helm_release" "aws_pod_identity_webhook" {
   }
 
   depends_on = [
-    time_sleep.wait_for_vcluster,
+    module.wait_for_vcluster,
     data.kubernetes_secret.vcluster_kubeconfig
   ]
 }


### PR DESCRIPTION
I really hope this doesn't take as long when running in CI compared to locally