### PR TITLE
fix: create dedicated cert-manager issuer for new vcluster zone

### DIFF
--- a/stages/apps/lead/issuer.tf
+++ b/stages/apps/lead/issuer.tf
@@ -1,3 +1,8 @@
+locals {
+  lets_encrypt_production_server = "https://acme-v02.api.letsencrypt.org/directory"
+  lets_encrypt_staging_server    = "https://acme-staging-v02.api.letsencrypt.org/directory"
+}
+
 resource "kubernetes_cluster_role" "cert_manager_cluster_role" {
   metadata {
     name = "cert-manager-cluster-role"
@@ -17,11 +22,11 @@ resource "kubernetes_cluster_role" "cert_manager_cluster_role" {
 
 module "cluster_issuer" {
   source        = "../../../modules/common/cert-issuer"
-  namespace     = var.toolchain_namespace
+  namespace     = module.toolchain_namespace.name
   issuer_name   = "letsencrypt-dns"
   issuer_kind   = "ClusterIssuer"
   issuer_type   = var.cert_issuer_type
-  issuer_server = "https://acme-v02.api.letsencrypt.org/directory"
+  issuer_server = local.lets_encrypt_production_server
 
   acme_solver       = "dns"
   provider_dns_type = "route53"
@@ -36,11 +41,11 @@ module "cluster_issuer" {
 
 module "staging_cluster_issuer" {
   source        = "../../../modules/common/cert-issuer"
-  namespace     = var.toolchain_namespace
+  namespace     = module.toolchain_namespace.name
   issuer_name   = "staging-letsencrypt-dns"
   issuer_kind   = "ClusterIssuer"
   issuer_type   = var.cert_issuer_type
-  issuer_server = "https://acme-staging-v02.api.letsencrypt.org/directory"
+  issuer_server = local.lets_encrypt_staging_server
 
   acme_solver       = "dns"
   provider_dns_type = "route53"

--- a/stages/apps/lead/variables.tf
+++ b/stages/apps/lead/variables.tf
@@ -8,6 +8,11 @@ variable "cluster_zone_id" {
   description = "Cluster zone id provided by cloud-provider stage"
 }
 
+variable "vcluster_zone_id" {
+  description = "Zone id for vclusters and vcluster applications provided by cloud-provider stage. Will be empty if vcluster is not enabled"
+  default     = ""
+}
+
 variable "aws_environment" {}
 
 variable "system_namespace" {

--- a/stages/apps/lead/vcluster.tf
+++ b/stages/apps/lead/vcluster.tf
@@ -55,7 +55,7 @@ module "vcluster_nginx" {
   namespace           = module.vcluster_namespace[0].name
   ingress_class       = local.vcluster_ingress_class
   default_certificate = "${module.vcluster_namespace[0].name}/${module.vcluster_apps_wildcard_cert[0].cert_secret_name}"
-  extra_args          = {
+  extra_args = {
     "enable-ssl-passthrough" : "true"
   }
 }

--- a/stages/apps/lead/vcluster.tf
+++ b/stages/apps/lead/vcluster.tf
@@ -14,6 +14,27 @@ module "vcluster_namespace" {
 // we can also reuse this nginx instance to front applications that are running on each vcluster. ingresses and
 // services are synced to the host cluster, so the host cluster needs an ingress controller that these synced ingresses
 // can use.
+module "vcluster_issuer" {
+  count  = var.enable_vcluster ? 1 : 0
+  source = "../../../modules/common/cert-issuer"
+
+  namespace     = module.vcluster_namespace[0].name
+  issuer_name   = "vcluster-letsencrypt-dns"
+  issuer_kind   = "ClusterIssuer"
+  issuer_type   = var.cert_issuer_type
+  issuer_server = local.lets_encrypt_production_server
+
+  acme_solver       = "dns"
+  provider_dns_type = "route53"
+
+  route53_dns_region      = var.region
+  route53_dns_hosted_zone = var.vcluster_zone_id
+
+  depends_on = [
+    module.cert_manager
+  ]
+}
+
 module "vcluster_apps_wildcard_cert" {
   count  = var.enable_vcluster ? 1 : 0
   source = "../../../modules/common/certificates"
@@ -22,8 +43,8 @@ module "vcluster_apps_wildcard_cert" {
   namespace = module.vcluster_namespace[0].name
   domain    = "apps.vcluster.${var.cluster_name}.${var.root_zone_name}"
 
-  issuer_name = module.cluster_issuer.issuer_name
-  issuer_kind = module.cluster_issuer.issuer_kind
+  issuer_name = module.vcluster_issuer[0].issuer_name
+  issuer_kind = module.vcluster_issuer[0].issuer_kind
 }
 
 module "vcluster_nginx" {
@@ -34,7 +55,7 @@ module "vcluster_nginx" {
   namespace           = module.vcluster_namespace[0].name
   ingress_class       = local.vcluster_ingress_class
   default_certificate = "${module.vcluster_namespace[0].name}/${module.vcluster_apps_wildcard_cert[0].cert_secret_name}"
-  extra_args = {
+  extra_args          = {
     "enable-ssl-passthrough" : "true"
   }
 }

--- a/stages/cloud-provider/aws/lead/outputs.tf
+++ b/stages/cloud-provider/aws/lead/outputs.tf
@@ -31,6 +31,11 @@ output "cluster_zone_id" {
   description = "Route53 zone id for EKS cluster; passed as input to app stage"
 }
 
+output "vcluster_zone_id" {
+  value       = var.enable_vcluster ? aws_route53_zone.vcluster[0].zone_id : ""
+  description = "Route53 zone id for vclusters running within the EKS cluster; passed as input to app stage"
+}
+
 output "external_dns_service_account_arn" {
   value = module.external_dns_iam.external_dns_service_account_arn
 }


### PR DESCRIPTION
I'm _reasonably_ sure this works, but let's encrypt is currently experiencing an outage so I haven't been able to test it yet.