### PR TITLE
fix: update kibana helm chart

### DIFF
--- a/modules/tools/kibana/main.tf
+++ b/modules/tools/kibana/main.tf
@@ -3,7 +3,7 @@ resource "helm_release" "kibana" {
   namespace  = var.namespace
   chart      = "kibana"
   repository = "https://helm.elastic.co"
-  version    = "7.6.2"
+  version    = "7.7.0"
   wait       = true
 
   values = [


### PR DESCRIPTION
- update helm chart from v7.6.2 to v7.7.0 to allow redirection on the readinessProbe to fix 302 status code error
- [release 7.7.0](https://github.com/elastic/helm-charts/releases/tag/7.7.0)