### PR TITLE
fix: update harbor k8s secret name for jenkins product

### DIFF
--- a/modules/lead/product-jenkins/main.tf
+++ b/modules/lead/product-jenkins/main.tf
@@ -38,7 +38,7 @@ provider "helm" {
 data "kubernetes_secret" "harbor_admin_creds" {
   provider = kubernetes.system
   metadata {
-    name      = "harbor-harbor-core"
+    name      = "harbor-core"
     namespace = var.toolchain_namespace
   }
 }


### PR DESCRIPTION
fixes where the SDM product for Jenkins looks for the Harbor k8s secret which was probably renamed after a recent upgrade