### PR TITLE
fix(eks): fix vcluster workflow by setting manage_aws_auth_configmap to true in EKS module  

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Create vcluster
         env:
           VCLUSTER_NAME: ${{ steps.vcluster-name.outputs.name }}
-          TERRAGRUNT_IAM_ROLE: "arn:aws:iam::265560927720:role/liatrio-lead-terraform-pipeline-service-account"
+          TERRAGRUNT_IAM_ROLE: ${{ secrets.AWS_LEAD_TERRAFORM_TEST_ROLE }}
         run: terragrunt apply --terragrunt-working-dir ./lead-environments/aws/vcluster -auto-approve
 
       - name: Run Tests
@@ -67,7 +67,7 @@ jobs:
           VCLUSTER_NAME: ${{ steps.vcluster-name.outputs.name }}
           TERRAGRUNT_IAM_ROLE: ${{ secrets.AWS_LEAD_TERRAFORM_TEST_ROLE }}
         run: |
-          aws sts assume-role --role-arn $TERRAGRUNT_IAM_ROLE --role-session-name ${{ steps.branch.outputs.current_branch }}-test >> role.json
+          aws sts assume-role --role-arn ${{ secrets.AWS_LEAD_TERRAFORM_TEST_ROLE }} --role-session-name ${{ steps.branch.outputs.current_branch }}-test >> role.json
           export AWS_ACCESS_KEY_ID=$(cat role.json | jq -rc .Credentials.AccessKeyId)
           export AWS_SECRET_ACCESS_KEY=$(cat role.json | jq -rc .Credentials.SecretAccessKey)
           export AWS_SESSION_TOKEN=$(cat role.json | jq -rc .Credentials.SessionToken)
@@ -91,5 +91,5 @@ jobs:
         if: github.ref == 'refs/heads/master'
         env:
           VCLUSTER_NAME: ${{ steps.vcluster-name.outputs.name }}
-          TERRAGRUNT_IAM_ROLE: "arn:aws:iam::${{ steps.account.outputs.number }}:role/Developer"
+          TERRAGRUNT_IAM_ROLE: ${{ secrets.AWS_LEAD_TERRAFORM_TEST_ROLE }}
         run: terragrunt destroy --terragrunt-working-dir ./lead-environments/aws/vcluster -auto-approve

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,15 +56,10 @@ jobs:
           branch=${{ steps.branch.outputs.current_branch }}
           echo "::set-output name=name::${branch//[^-a-z0-9]/-}-vcluster"
 
-      - name: Sleep
-        env:
-          TERRAGRUNT_IAM_ROLE: ${{ secrets.AWS_LEAD_TERRAFORM_TEST_ROLE }}
-        run: sleep 1440
-
       - name: Create vcluster
         env:
           VCLUSTER_NAME: ${{ steps.vcluster-name.outputs.name }}
-          TERRAGRUNT_IAM_ROLE: ${{ secrets.AWS_LEAD_TERRAFORM_TEST_ROLE }}
+          TERRAGRUNT_IAM_ROLE: "arn:aws:iam::265560927720:role/liatrio-lead-terraform-pipeline-service-account"
         run: terragrunt apply --terragrunt-working-dir ./lead-environments/aws/vcluster -auto-approve
 
       - name: Run Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,9 @@ jobs:
           branch=${{ steps.branch.outputs.current_branch }}
           echo "::set-output name=name::${branch//[^-a-z0-9]/-}-vcluster"
 
+      - name: Sleep
+        run: sleep 1440
+
       - name: Create vcluster
         env:
           VCLUSTER_NAME: ${{ steps.vcluster-name.outputs.name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,11 +56,6 @@ jobs:
           branch=${{ steps.branch.outputs.current_branch }}
           echo "::set-output name=name::${branch//[^-a-z0-9]/-}-vcluster"
 
-      - name: Get AWS Account Number
-        id: account
-        run: |
-          echo "::set-output name=number::$(cat aws/accounts.json | jq -rc '.[] | select(.name == "${{ matrix.env }}") | .account')"
-
       - name: Create vcluster
         env:
           VCLUSTER_NAME: ${{ steps.vcluster-name.outputs.name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,18 +57,20 @@ jobs:
           echo "::set-output name=name::${branch//[^-a-z0-9]/-}-vcluster"
 
       - name: Sleep
+        env:
+          TERRAGRUNT_IAM_ROLE: ${{ secrets.AWS_LEAD_TERRAFORM_TEST_ROLE }}
         run: sleep 1440
 
       - name: Create vcluster
         env:
           VCLUSTER_NAME: ${{ steps.vcluster-name.outputs.name }}
-          TERRAGRUNT_IAM_ROLE: "arn:aws:iam::281127131043:role/Developer"
+          TERRAGRUNT_IAM_ROLE: ${{ secrets.AWS_LEAD_TERRAFORM_TEST_ROLE }}
         run: terragrunt apply --terragrunt-working-dir ./lead-environments/aws/vcluster -auto-approve
 
       - name: Run Tests
         env:
           VCLUSTER_NAME: ${{ steps.vcluster-name.outputs.name }}
-          TERRAGRUNT_IAM_ROLE: "arn:aws:iam::281127131043:role/Developer"
+          TERRAGRUNT_IAM_ROLE: ${{ secrets.AWS_LEAD_TERRAFORM_TEST_ROLE }}
         run: |
           aws sts assume-role --role-arn $TERRAGRUNT_IAM_ROLE --role-session-name ${{ steps.branch.outputs.current_branch }}-test >> role.json
           export AWS_ACCESS_KEY_ID=$(cat role.json | jq -rc .Credentials.AccessKeyId)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,18 +56,23 @@ jobs:
           branch=${{ steps.branch.outputs.current_branch }}
           echo "::set-output name=name::${branch//[^-a-z0-9]/-}-vcluster"
 
+      - name: Get AWS Account Number
+        id: account
+        run: |
+          echo "::set-output name=number::$(cat aws/accounts.json | jq -rc '.[] | select(.name == "${{ matrix.env }}") | .account')"
+
       - name: Create vcluster
         env:
           VCLUSTER_NAME: ${{ steps.vcluster-name.outputs.name }}
-          TERRAGRUNT_IAM_ROLE: ${{ secrets.AWS_LEAD_TERRAFORM_TEST_ROLE }}
+          TERRAGRUNT_IAM_ROLE: "arn:aws:iam::281127131043:role/Developer"
         run: terragrunt apply --terragrunt-working-dir ./lead-environments/aws/vcluster -auto-approve
 
       - name: Run Tests
         env:
           VCLUSTER_NAME: ${{ steps.vcluster-name.outputs.name }}
-          TERRAGRUNT_IAM_ROLE: ${{ secrets.AWS_LEAD_TERRAFORM_TEST_ROLE }}
+          TERRAGRUNT_IAM_ROLE: "arn:aws:iam::281127131043:role/Developer"
         run: |
-          aws sts assume-role --role-arn ${{ secrets.AWS_LEAD_TERRAFORM_TEST_ROLE }} --role-session-name ${{ steps.branch.outputs.current_branch }}-test >> role.json
+          aws sts assume-role --role-arn $TERRAGRUNT_IAM_ROLE --role-session-name ${{ steps.branch.outputs.current_branch }}-test >> role.json
           export AWS_ACCESS_KEY_ID=$(cat role.json | jq -rc .Credentials.AccessKeyId)
           export AWS_SECRET_ACCESS_KEY=$(cat role.json | jq -rc .Credentials.SecretAccessKey)
           export AWS_SESSION_TOKEN=$(cat role.json | jq -rc .Credentials.SessionToken)
@@ -91,5 +96,5 @@ jobs:
         if: github.ref == 'refs/heads/master'
         env:
           VCLUSTER_NAME: ${{ steps.vcluster-name.outputs.name }}
-          TERRAGRUNT_IAM_ROLE: ${{ secrets.AWS_LEAD_TERRAFORM_TEST_ROLE }}
+          TERRAGRUNT_IAM_ROLE: "arn:aws:iam::${{ steps.account.outputs.number }}:role/Developer"
         run: terragrunt destroy --terragrunt-working-dir ./lead-environments/aws/vcluster -auto-approve

--- a/modules/environment/aws/eks/main.tf
+++ b/modules/environment/aws/eks/main.tf
@@ -204,6 +204,7 @@ module "eks" {
     }
   }
 
+  manage_aws_auth_configmap     = true
   aws_auth_roles                = concat(local.default_roles, local.codebuild_roles, var.additional_mapped_roles)
   iam_role_permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/Developer"
   enable_irsa                   = true


### PR DESCRIPTION
This adds the roles to the `aws-auth` `ConfigMap` resource and therefore allows `Developer` and other assumed roles to interact with the cluster.