### PR TITLE
fix: add exclusion on elasticsearch-curtor-values.tpl

### DIFF
--- a/modules/tools/elasticsearch/elasticsearch-curator-values.tpl
+++ b/modules/tools/elasticsearch/elasticsearch-curator-values.tpl
@@ -13,8 +13,7 @@ configMaps:
         filters:
         - filtertype: pattern
           kind: regex
-          value: 'actions-[0-9]{4}-[0-9]{2}'
-          exclude: True
+          value: '(jaeger-jaeger-|kubernetes_cluster-).*'
         - filtertype: age
           source: creation_date
           direction: older

--- a/modules/tools/elasticsearch/elasticsearch-curator-values.tpl
+++ b/modules/tools/elasticsearch/elasticsearch-curator-values.tpl
@@ -11,6 +11,10 @@ configMaps:
           disable_action: False
           ignore_empty_list: True
         filters:
+        - filtertype: pattern
+          kind: regex
+          value: 'actions-[0-9]{4}-[0-9]{2}'
+          exclude: True
         - filtertype: age
           source: creation_date
           direction: older


### PR DESCRIPTION
We want to include a filter on the delete old indices action that excludes the github actions metrics indices. We want to exclude these repos because we want historical data.
