### PR TITLE
ci: refactor tfsec workflow

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -63,11 +63,6 @@ jobs:
   terraform_format:
     name: "Format"
     runs-on: ubuntu-latest
-    strategy:
-        # ↓ create dynamic matrix from the json
-        matrix:
-          validate: ${{ fromJson(needs.discover_stages.outputs.matrix) }}
-        fail-fast: false
 
     steps:
       - name: Checkout
@@ -78,7 +73,7 @@ jobs:
 
       # Checks that all Terraform configuration files adhere to a canonical format
       - name: Terraform Format
-        run: terraform fmt -check
+        run: terraform fmt -check --recursive
 
       # TODO: need to setup go?
 
@@ -86,18 +81,15 @@ jobs:
         run: go install github.com/aquasecurity/tfsec/cmd/tfsec@v1.26.3
 
       - name: Run tfsec on each folder
-        env:
-          FOLDER: ${{ matrix.validate }}
         run: |
-          cd $FOLDER
-
           tfsec \
           -e general-secrets-sensitive-in-variable,general-secrets-sensitive-in-local,general-secrets-sensitive-in-attribute \
           --format sarif \
-          --out tfsec.sarif
+          --out tfsec.sarif \
+          --force-all-dirs
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif
+        uses: github/codeql-action/upload-sarif@v1
         with:
           sarif-file: ./tfsec.sarif
 

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -87,15 +87,16 @@ jobs:
         run: |
           tfsec \
           -e general-secrets-sensitive-in-variable,general-secrets-sensitive-in-local,general-secrets-sensitive-in-attribute \
-          --format sarif \
-          --out tfsec.sarif \
-          --force-all-dirs
+          --format=sarif \
+          --out=tfsec.sarif \
+          --force-all-dirs \
+          --soft-fail
 
       - name: Upload SARIF file
         if: always()
         uses: github/codeql-action/upload-sarif@v2
         with:
-          sarif_file: ./tfsec.sarif
+          sarif_file: tfsec.sarif
 
       # TODO: incorporate tflint
 

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -63,7 +63,12 @@ jobs:
   terraform_format:
     name: "Format"
     runs-on: ubuntu-latest
-
+    needs: discover_stages
+    strategy:
+        # ↓ create dynamic matrix from the json
+        matrix:
+          validate: ${{ fromJson(needs.discover_stages.outputs.matrix) }}
+        fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -92,6 +97,7 @@ jobs:
         uses: reviewdog/action-tflint@v1.13.0
         if: ${{ always() }}
         with:
+          working_directory: ${{ matrix.validate }}
           github_token: ${{ secrets.github_token }}
           fail_on_error: "true"
           filter_mode: "nofilter"

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -75,7 +75,10 @@ jobs:
       - name: Terraform Format
         run: terraform fmt -check --recursive
 
-      # TODO: need to setup go?
+      - name: Setup Go environment
+        uses: actions/setup-go@v3.2.1
+        with:
+          go-version: '^v1.18.0'
 
       - name: Install tfsec
         run: go install github.com/aquasecurity/tfsec/cmd/tfsec@v1.26.3

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -95,7 +95,7 @@ jobs:
         if: always()
         uses: github/codeql-action/upload-sarif@v1
         with:
-          sarif-file: ./tfsec.sarif
+          sarif_file: ./tfsec.sarif
 
       # TODO: incorporate tflint
 

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -19,7 +19,7 @@ jobs:
       # here we create the json, we need the "id:" so we can use it in "outputs" below
       - id: set-matrix
         # find tf files in all folders, trim to path, store as array, remove any empty.
-        run: echo "::set-output name=matrix::$(find . -name *.tf | sed 's:[^/]*$::' | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')"
+        run: echo "::set-output name=matrix::$(find stages -name *.tf | sed 's:[^/]*$::' | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')"
     outputs:
         matrix: ${{ steps.set-matrix.outputs.matrix }}
 

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -2,43 +2,37 @@ name: "Terraform Code Quality"
 
 on:
   pull_request:
+    branches:
+      - "master"
   push:
+    branches:
+      - "master"
 
 jobs:
-
-  discover_stages:
+  discover:
     name: Discover
     runs-on: ubuntu-latest
     steps:
-
       - name: Checkout
         uses: actions/checkout@v2
 
       # here we create the json, we need the "id:" so we can use it in "outputs" below
       - id: set-matrix
-
-        # find main.tf files in stages folder, trim to path, store as array, remove any empty.
-        run: echo "::set-output name=matrix::$(find stages -name main.tf | sed 's:[^/]*$::' | jq -R -s -c 'split("\n") | map(select(length > 0))')"
-
+        # find tf files in all folders, trim to path, store as array, remove any empty.
+        run: echo "::set-output name=matrix::$(find . -name *.tf | sed 's:[^/]*$::' | jq -R -s -c 'split("\n") | map(select(length > 0))')"
     outputs:
         matrix: ${{ steps.set-matrix.outputs.matrix }}
 
   terraform_validate:
     name: "Validate"
     runs-on: ubuntu-latest
-
-    needs: discover_stages
+    needs: discover
     strategy:
         # ↓ create dynamic matrix from the json
         matrix:
-          validate: ${{ fromJson(needs.discover_stages.outputs.matrix) }}
+          validate: ${{ fromJson(needs.discover.outputs.matrix) }}
         fail-fast: false
-    defaults:
-      run:
-        shell: bash
-
     steps:
-
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -60,6 +54,19 @@ jobs:
           terraform init -backend=false
           terraform validate
 
+      - name: Run tfsec
+        uses: aquasecurity/tfsec-sarif-action@v0.1.3
+        with:
+          sarif_file: tfsec.sarif
+          working_directory: ${{ matrix.validate }}
+          tfsec_args: "-e general-secrets-sensitive-in-variable,general-secrets-sensitive-in-local,general-secrets-sensitive-in-attribute"
+
+      - name: Upload SARIF file
+        if: always()
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: tfsec.sarif
+
       - name: Run tflint with reviewdog
         uses: reviewdog/action-tflint@v1.17.0
         if: always()
@@ -70,7 +77,7 @@ jobs:
           filter_mode: "nofilter"
           reporter: github-pr-review
 
-  tfsec:
+  terraform_format:
     name: "TFSec and Terraform Format"
     runs-on: ubuntu-latest
     steps:
@@ -83,16 +90,3 @@ jobs:
       # Checks that all Terraform configuration files adhere to a canonical format
       - name: Terraform Format
         run: terraform fmt -check --recursive
-
-      - name: Run tfsec with sarif upload
-        uses: aquasecurity/tfsec-sarif-action@v0.1.3
-        with:
-          sarif_file: tfsec.sarif
-          full_repo_scan: true
-          tfsec_args: "-e general-secrets-sensitive-in-variable,general-secrets-sensitive-in-local,general-secrets-sensitive-in-attribute"
-
-      - name: Upload SARIF file
-        if: always()
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: tfsec.sarif

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -75,15 +75,6 @@ jobs:
       - name: Terraform Format
         run: terraform fmt -check --recursive
 
-      - name: Setup Go environment
-        uses: actions/setup-go@v3.2.1
-        with:
-          go-version: '^v1.18.0'
-          cache: true
-
-      - name: Install tfsec
-        run: go install github.com/aquasecurity/tfsec/cmd/tfsec@v1.26.3
-
       - name: Run tfsec with sarif upload
         uses: aquasecurity/tfsec-sarif-action@v0.1.3
         with: 
@@ -97,12 +88,10 @@ jobs:
         with:
           sarif_file: tfsec.sarif
 
-      # TODO: incorporate tflint
-
-      # - name: Run tflint with reviewdog
-      #   uses: reviewdog/action-tflint@v1.13.0
-      #   if: ${{ always() }}
-      #   with:
-      #     github_token: ${{ secrets.github_token }}
-      #     fail_on_error: "true"
-      #     filter_mode: "nofilter"
+      - name: Run tflint with reviewdog
+        uses: reviewdog/action-tflint@v1.13.0
+        if: ${{ always() }}
+        with:
+          github_token: ${{ secrets.github_token }}
+          fail_on_error: "true"
+          filter_mode: "nofilter"

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -79,18 +79,17 @@ jobs:
         uses: actions/setup-go@v3.2.1
         with:
           go-version: '^v1.18.0'
+          cache: true
 
       - name: Install tfsec
         run: go install github.com/aquasecurity/tfsec/cmd/tfsec@v1.26.3
 
-      - name: Run tfsec on each folder
-        run: |
-          tfsec \
-          -e general-secrets-sensitive-in-variable,general-secrets-sensitive-in-local,general-secrets-sensitive-in-attribute \
-          --format=sarif \
-          --out=tfsec.sarif \
-          --force-all-dirs \
-          --soft-fail
+      - name: Run tfsec with sarif upload
+        uses: aquasecurity/tfsec-sarif-action@v0.1.3
+        with: 
+          sarif_file: tfsec.sarif
+          full_repo_scan: true
+          tfsec_args: "-e general-secrets-sensitive-in-variable,general-secrets-sensitive-in-local,general-secrets-sensitive-in-attribute"
 
       - name: Upload SARIF file
         if: always()

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Upload SARIF file
         if: always()
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: ./tfsec.sarif
 

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -19,12 +19,12 @@ jobs:
       # here we create the json, we need the "id:" so we can use it in "outputs" below
       - id: set-matrix
         # find tf files in all folders, trim to path, store as array, remove any empty.
-        run: echo "::set-output name=matrix::$(find . -name *.tf | sed 's:[^/]*$::' | jq -R -s -c 'split("\n") | map(select(length > 0))')"
+        run: echo "::set-output name=matrix::$(find . -name *.tf | sed 's:[^/]*$::' | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')"
     outputs:
         matrix: ${{ steps.set-matrix.outputs.matrix }}
 
   terraform_validate:
-    name: "Validate"
+    name: Validate
     runs-on: ubuntu-latest
     needs: discover
     strategy:
@@ -54,7 +54,7 @@ jobs:
           terraform init -backend=false
           terraform validate
 
-      - name: Run tfsec
+      - name: tfsec
         uses: aquasecurity/tfsec-sarif-action@v0.1.3
         with:
           sarif_file: tfsec.sarif
@@ -78,7 +78,7 @@ jobs:
           reporter: github-pr-review
 
   terraform_format:
-    name: "TFSec and Terraform Format"
+    name: Format
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -63,12 +63,13 @@ jobs:
   terraform_format:
     name: "Format"
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
+    strategy:
+        # ↓ create dynamic matrix from the json
+        matrix:
+          validate: ${{ fromJson(needs.discover_stages.outputs.matrix) }}
+        fail-fast: false
 
     steps:
-
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -77,22 +78,35 @@ jobs:
 
       # Checks that all Terraform configuration files adhere to a canonical format
       - name: Terraform Format
-        run: terraform fmt -check -recursive
+        run: terraform fmt -check
 
-      - name: Run tfsec with reviewdog
-        uses: reviewdog/action-tfsec@v1.11.0
-        if: ${{ always() }}
-        with:
-          github_token: ${{ secrets.github_token }}
-          tfsec_version: "v0.63.1"
-          fail_on_error: "true"
-          filter_mode: "nofilter"
-          tfsec_flags: "-e general-secrets-sensitive-in-variable,general-secrets-sensitive-in-local,general-secrets-sensitive-in-attribute"
+      # TODO: need to setup go?
 
-      - name: Run tflint with reviewdog
-        uses: reviewdog/action-tflint@v1.13.0
-        if: ${{ always() }}
+      - name: Install tfsec
+        run: go install github.com/aquasecurity/tfsec/cmd/tfsec@v1.26.3
+
+      - name: Run tfsec on each folder
+        env:
+          FOLDER: ${{ matrix.validate }}
+        run: |
+          cd $FOLDER
+
+          tfsec \
+          -e general-secrets-sensitive-in-variable,general-secrets-sensitive-in-local,general-secrets-sensitive-in-attribute \
+          --format sarif \
+          --out tfsec.sarif
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif
         with:
-          github_token: ${{ secrets.github_token }}
-          fail_on_error: "true"
-          filter_mode: "nofilter"
+          sarif-file: ./tfsec.sarif
+
+      # TODO: incorporate tflint
+
+      # - name: Run tflint with reviewdog
+      #   uses: reviewdog/action-tflint@v1.13.0
+      #   if: ${{ always() }}
+      #   with:
+      #     github_token: ${{ secrets.github_token }}
+      #     fail_on_error: "true"
+      #     filter_mode: "nofilter"

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Run tfsec with sarif upload
         uses: aquasecurity/tfsec-sarif-action@v0.1.3
-        with: 
+        with:
           sarif_file: tfsec.sarif
           full_repo_scan: true
           tfsec_args: "-e general-secrets-sensitive-in-variable,general-secrets-sensitive-in-local,general-secrets-sensitive-in-attribute"
@@ -96,7 +96,6 @@ jobs:
         matrix:
           validate: ${{ fromJson(needs.discover_stages.outputs.matrix) }}
         fail-fast: false
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -109,4 +108,3 @@ jobs:
           github_token: ${{ secrets.github_token }}
           fail_on_error: "true"
           filter_mode: "nofilter"
-    

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -2,14 +2,10 @@ name: "Terraform Code Quality"
 
 on:
   pull_request:
-    branches:
-      - "master"
   push:
-    branches:
-      - "master"
 
 jobs:
-  discover:
+  discover_stages:
     name: Discover
     runs-on: ubuntu-latest
     steps:
@@ -26,11 +22,11 @@ jobs:
   terraform_validate:
     name: Validate
     runs-on: ubuntu-latest
-    needs: discover
+    needs: discover_stages
     strategy:
         # ↓ create dynamic matrix from the json
         matrix:
-          validate: ${{ fromJson(needs.discover.outputs.matrix) }}
+          validate: ${{ fromJson(needs.discover_stages.outputs.matrix) }}
         fail-fast: false
     steps:
       - name: Checkout

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -61,13 +61,14 @@ jobs:
           terraform validate
 
       - name: Run tflint with reviewdog
-        uses: reviewdog/action-tflint@v1.13.0
+        uses: reviewdog/action-tflint@v1.17.0
         if: always()
         with:
           working_directory: ${{ matrix.validate }}
           github_token: ${{ secrets.github_token }}
           fail_on_error: "true"
           filter_mode: "nofilter"
+          reporter: github-pr-review
 
   tfsec:
     name: "TFSec and Terraform Format"

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -60,15 +60,9 @@ jobs:
           terraform init -backend=false
           terraform validate
 
-  terraform_format:
-    name: "Format"
+  tfsec:
+    name: "TFSec and Terraform Format"
     runs-on: ubuntu-latest
-    needs: discover_stages
-    strategy:
-        # ↓ create dynamic matrix from the json
-        matrix:
-          validate: ${{ fromJson(needs.discover_stages.outputs.matrix) }}
-        fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -93,6 +87,20 @@ jobs:
         with:
           sarif_file: tfsec.sarif
 
+  tflint:
+    name: "TFLint"
+    runs-on: ubuntu-latest
+    needs: discover_stages
+    strategy:
+        # ↓ create dynamic matrix from the json
+        matrix:
+          validate: ${{ fromJson(needs.discover_stages.outputs.matrix) }}
+        fail-fast: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
       - name: Run tflint with reviewdog
         uses: reviewdog/action-tflint@v1.13.0
         if: ${{ always() }}
@@ -101,3 +109,4 @@ jobs:
           github_token: ${{ secrets.github_token }}
           fail_on_error: "true"
           filter_mode: "nofilter"
+    

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -92,6 +92,7 @@ jobs:
           --force-all-dirs
 
       - name: Upload SARIF file
+        if: always()
         uses: github/codeql-action/upload-sarif@v1
         with:
           sarif-file: ./tfsec.sarif

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -60,6 +60,15 @@ jobs:
           terraform init -backend=false
           terraform validate
 
+      - name: Run tflint with reviewdog
+        uses: reviewdog/action-tflint@v1.13.0
+        if: always()
+        with:
+          working_directory: ${{ matrix.validate }}
+          github_token: ${{ secrets.github_token }}
+          fail_on_error: "true"
+          filter_mode: "nofilter"
+
   tfsec:
     name: "TFSec and Terraform Format"
     runs-on: ubuntu-latest
@@ -86,25 +95,3 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: tfsec.sarif
-
-  tflint:
-    name: "TFLint"
-    runs-on: ubuntu-latest
-    needs: discover_stages
-    strategy:
-        # ↓ create dynamic matrix from the json
-        matrix:
-          validate: ${{ fromJson(needs.discover_stages.outputs.matrix) }}
-        fail-fast: false
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Run tflint with reviewdog
-        uses: reviewdog/action-tflint@v1.13.0
-        if: ${{ always() }}
-        with:
-          working_directory: ${{ matrix.validate }}
-          github_token: ${{ secrets.github_token }}
-          fail_on_error: "true"
-          filter_mode: "nofilter"


### PR DESCRIPTION
This PR changes the codeql-workflow so that when we run tfsec we will upload the results of the scan to GitHub's security tab. This is a refactor from before in which reviewdog would add comments to one's PR that introduced new tfsec alerts.
