### PR TITLE
fix:  modified each statement for namespace

### DIFF
--- a/stages/apps/lead/github-runners.tf
+++ b/stages/apps/lead/github-runners.tf
@@ -85,6 +85,6 @@ module "github_runner_binding" {
   for_each = toset(var.github_runners_namespaces)
 
   group_name = var.github_runners_group_name
-  namespace  = each.key   
+  namespace  = each.key
   role_name  = kubernetes_cluster_role.cluster_role.metadata[0].name
 }

--- a/stages/apps/lead/github-runners.tf
+++ b/stages/apps/lead/github-runners.tf
@@ -85,6 +85,6 @@ module "github_runner_binding" {
   for_each = toset(var.github_runners_namespaces)
 
   group_name = var.github_runners_group_name
-  namespace  = each.value
+  namespace  = each.key   
   role_name  = kubernetes_cluster_role.cluster_role.metadata[0].name
 }


### PR DESCRIPTION
FLY-85

Each statement was failing to iterate through the list when set to reference by value.  This was resulting in the existing namespaces being set to destroy and never creating the new ones added.  Adjusted the each to iterate through keys and it now works as expected.